### PR TITLE
ci: add minimal travis config (build --tests) + fix error in vdom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: rust
+rust:
+  - nightly
+os:
+  - linux
+  - osx
+  - windows
+before_script:
+  - rustup target add wasm32-unknown-unknown
+  - cargo install wasm-bindgen-cli
+script:
+  - cargo build --tests --target wasm32-unknown-unknown

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -521,7 +521,8 @@ pub mod tests {
     use super::*;
 
     use crate as seed;  // required for macros to work.
-    use crate::dom_types::{UpdateListener, UpdateEl};
+    use crate::dom_types::{UpdateEl};
+    use crate::{div,li};
 
     fn make_doc() -> web_sys::Document {
         let window = web_sys::window().unwrap();


### PR DESCRIPTION
I was not able to enable the tests on travis, but enabling the build let me catch a small error in one test.

A new PR will follow if I'll manage travis to run the tests too.