### PR TITLE
ci: Enable test with wasm-bindgen-test and wasm-pack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ rust:
 os:
   - linux
   - osx
-  - windows
+  #- windows
+addons:
+  firefox: latest
+cache: cargo
 before_script:
   - rustup target add wasm32-unknown-unknown
-  - cargo install wasm-bindgen-cli
+  - cargo install wasm-bindgen-cli --vers 0.2.29 || true
+  - cargo install wasm-pack --vers 0.5.1 || true
 script:
   - cargo build --tests --target wasm32-unknown-unknown
+  - wasm-pack test --headless --firefox

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ keywords = ["wasm", "webassembly", "frontend", "framework", "web"]
 categories = ["wasm", "web-programming"]
 edition = "2018"
 
-#[lib]
+[lib]
+crate-type = ["cdylib", "rlib"]
 #proc-macro = true
+
+[dev-dependencies]
+wasm-bindgen-test = "^0.2.29" # NOTE: keep in sync with wasm-bindgen version
 
 [dependencies]
 wasm-bindgen = {version = "^0.2.29", features = ["serde-serialize"]}

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -518,7 +518,12 @@ pub trait DomEl<Tg, At, Sty, Tx, Ls, E>
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
+   #![feature(custom_attribute)]
+   use wasm_bindgen_test::wasm_bindgen_test_configure;
+   wasm_bindgen_test_configure!(run_in_browser);
+
+   use wasm_bindgen_test::*;
+   use super::*;
 
     use crate as seed;  // required for macros to work.
     use crate::dom_types::{UpdateEl};
@@ -533,7 +538,7 @@ pub mod tests {
     enum Msg {}
 
 
-    #[test]
+    #[wasm_bindgen_test]
     fn el_added() {
         // todo macros not working here.
         let old_vdom: El<Msg> = div![ "text", vec![


### PR DESCRIPTION
- add firefox as addon
- cache cargo (allow failure on cargo install)
- disable windows because of https://travis-ci.org/naufraghi/seed/jobs/475998812#L630