### PR TITLE
Return App from seed::run

### DIFF
--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -440,7 +440,7 @@ pub fn run<Ms, Mdl>(
     mount_point_id: &str,
     routes: Option<HashMap<String, Ms>>,
     window_events: Option<fn(Mdl) -> Vec<dom_types::Listener<Ms>>>,
-)
+) -> App<Ms,Mdl>
     where Ms: Clone + 'static, Mdl: Clone + 'static
 {
     let app = App::new(model.clone(), update, view, mount_point_id, routes.clone(), window_events);
@@ -487,12 +487,13 @@ pub fn run<Ms, Mdl>(
     // If a route map is inlcluded, update the state on page load, based
     // on the starting URL. Must be set up on the server as well.
     if let Some(routes_inner) = routes {
-        let app2 = crate::routing::initial(app, routes_inner.clone());
+        let app2 = crate::routing::initial(app.clone(), routes_inner.clone());
         crate::routing::update_popstate_listener(&app2, routes_inner);
     }
 
     // Allows panic messages to output to the browser console.error.
     panic::set_hook(Box::new(console_error_panic_hook::hook));
+    app
 }
 
 pub trait Attrs: PartialEq + ToString {


### PR DESCRIPTION
Modifying the app state from the outside
could be helpfull, eg.:

```rust
pub fn render() {
    let app = seed::run(Model::default(), update, view, "app", None, None);
    open_websockets(app);
}

fn open_websockets(state: seed::App<Msg, Model>) {

  // setup websockets ...

  let on_message = Box::new(move|ev: MessageEvent| {
    let txt = ev.data().as_string().unwrap();
    let json = : JsonMsg = serde_json::from_str(&text).unwrap();
    state.update(Msg::Json(json));
  });
}
```