### PR TITLE
Do not wrap raw_html elements with a span

### DIFF
--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -134,6 +134,9 @@ pub fn make_websys_el<Ms: Clone>(
                 .expect("Missing text on raw HTML element"),
         );
 
+        // We know that there is a child because we just attached it
+        let el_ws = el_ws.first_element_child().unwrap();
+
         // todo DRY
         if el_vdom.style.vals.keys().len() > 0 {
             el_ws


### PR DESCRIPTION
Using El::from_html wraps the created DOM node in a ```<span>```.
```
    pub fn from_html(html: &str) -> Self {
        let mut result = Self::empty(Tag::Span);
        result.raw_html = true;
        result.text = Some(html.into());
        result
    }
``` 
This was surprising and caused me some problems when porting some HTML which expected parent-child relationships to remain intact.

 In the case that this was not intended this PR removes the ```<span>```, rendering only its child which is the node created from the raw_html string. 

If it was intended, would mind explaining the reasoning? 

Thank you.