### PR TITLE
&mut for Update + returning Futures from Update

### DIFF
--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -30,33 +30,23 @@ enum Msg {
     ChangeWWC(String),
 }
 
-/// The sole source of updating the model; returns a fresh one.
-fn update(msg: Msg, model: Model) -> Update<Msg, Model> {
+/// The sole source of updating the model
+fn update(msg: Msg, model: &mut Model) -> Update<Msg> {
     match msg {
-        Msg::Increment => Render(Model {
-            count: model.count + 1,
-            ..model
-        }),
-        Msg::Decrement => Render(Model {
-            count: model.count - 1,
-            ..model
-        }),
-        Msg::ChangeWWC(what_we_count) => Render(Model {
-            what_we_count,
-            ..model
-        })
+        Msg::Increment => {
+            model.count += 1;
+            Render
+        }
+        Msg::Decrement => {
+            model.count -= 1;
+            Render
+        }
+        Msg::ChangeWWC(what_we_count) => {
+            model.what_we_count = what_we_count;
+            Render
+        }
     }
 }
-
-/// A mutable-style alternative:
-//fn update(msg: Msg, model: mut Model) -> ModelUpdate<Model> {
-//    match msg {
-//        Msg::Increment => model.count += 1,
-//        Msg::Decrement => model.count -= 1,
-//        Msg::ChangeWWC(what_we_count) => model.what_we_count = what_we_count,
-//    }
-//    Render(model)
-//}
 
 // View
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -63,7 +63,7 @@ fn success_level(clicks: i32) -> El<Msg> {
 
 /// The top-level component we pass to the virtual dom. Must accept the model as its
 /// only argument, and output a single El.
-fn view(_state: seed::App<Msg, Model>, model: &Model) -> El<Msg> {
+fn view(model: &Model) -> El<Msg> {
     let plural = if model.count == 1 { "" } else { "s" };
     let text = format!("{} {}{} so far", model.count, model.what_we_count, plural);
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -35,15 +35,15 @@ fn update(msg: Msg, model: &mut Model) -> Update<Msg> {
     match msg {
         Msg::Increment => {
             model.count += 1;
-            Render
+            Render.into()
         }
         Msg::Decrement => {
             model.count -= 1;
-            Render
+            Render.into()
         }
         Msg::ChangeWWC(what_we_count) => {
             model.what_we_count = what_we_count;
-            Render
+            Render.into()
         }
     }
 }

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -102,9 +102,9 @@ fn update(msg: Msg, model: &mut Model) -> Update<Msg> {
             Render.into()
         }
 
-        Msg::GetData => Update::with_future(get_data()).skip(),
+        Msg::GetData => Update::with_future_msg(get_data()).skip(),
 
-        Msg::Send => Update::with_future(send()).skip(),
+        Msg::Send => Update::with_future_msg(send()).skip(),
 
         Msg::OnServerResponse(result) => {
             log!(format!("Response: {:?}", result));

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -112,7 +112,7 @@ fn update(msg: Msg, model: &mut Model) -> Update<Msg> {
 
 // View
 
-fn view(_state: seed::App<Msg, Model>, model: &Model) -> El<Msg> {
+fn view(model: &Model) -> El<Msg> {
     div![
         div![
             format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,7 @@ pub mod prelude {
             will_unmount, At, El, Ev, Optimize::Key, Tag, UpdateEl,
         },
         shortcuts::*, // appears not to work.
-//        vdom::{Update, Update::Render, Update::Skip, Update::RenderThen},
-        vdom::{Update, Update::*},
+        vdom::{ShouldRender, ShouldRender::*, Update},
     };
     pub use std::collections::HashMap;
 
@@ -137,7 +136,7 @@ pub mod tests {
             match msg {
                 Msg::Increment => {
                     model.val += 1;
-                    Update::Render
+                    Render.into()
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,12 @@ pub mod tests {
             Increment,
         }
 
-        fn update(msg: Msg, model: Model) -> Update<Msg, Model> {
+        fn update(msg: Msg, model: &mut Model) -> Update<Msg> {
             match msg {
-                Msg::Increment => Update::Render(Model { val: model.val + 1 }),
+                Msg::Increment => {
+                    model.val += 1;
+                    Update::Render
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub mod tests {
             }
         }
 
-        fn view(_state: seed::App<Msg, Model>, _model: &Model) -> El<Msg> {
+        fn view(_model: &Model) -> El<Msg> {
             div!["Hello world"]
         }
 

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -73,7 +73,7 @@ impl<Ms> Update<Ms> {
 
 
 type UpdateFn<Ms, Mdl> = fn(Ms, &mut Mdl) -> Update<Ms>;
-type ViewFn<Ms, Mdl> = fn(App<Ms, Mdl>, &Mdl) -> El<Ms>;
+type ViewFn<Ms, Mdl> = fn(&Mdl) -> El<Ms>;
 type RoutesFn<Ms> = fn(&crate::routing::Url) -> Ms;
 type WindowEvents<Ms, Mdl> = fn(&Mdl) -> Vec<dom_types::Listener<Ms>>;
 type MsgListeners<Ms> = Vec<Box<Fn(&Ms)>>;
@@ -252,7 +252,7 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
 
         let window = util::window();
 
-        let mut topel_vdom = (self.cfg.view)(self.clone(), &self.data.model.borrow());
+        let mut topel_vdom = (self.cfg.view)(&self.data.model.borrow());
 
         // TODO: use window events
         if self.cfg.window_events.is_some() {
@@ -335,7 +335,7 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
         if should_render == ShouldRender::Render {
             // Create a new vdom: The top element, and all its children. Does not yet
             // have associated web_sys elements.
-            let mut topel_new_vdom = (self.cfg.view)(self.clone(), &self.data.model.borrow());
+            let mut topel_new_vdom = (self.cfg.view)(&self.data.model.borrow());
 
             // We setup the vdom (which populates web_sys els through it, but don't
             // render them with attach_children; we try to do it cleverly via patch().

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -7,10 +7,46 @@ use std::{cell::RefCell, collections::HashMap, panic, rc::Rc};
 use wasm_bindgen::closure::Closure;
 use web_sys::{Document, Element, Event, EventTarget, Window};
 
-pub enum Update<Ms> {
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ShouldRender {
     Render,
     Skip,
-    RenderThen(Ms),
+}
+
+impl Default for ShouldRender {
+    fn default() -> Self {
+        ShouldRender::Render
+    }
+}
+
+#[derive(Debug)]
+pub struct Update<Ms> {
+    should_render: ShouldRender,
+    effect_msg: Option<Ms>,
+}
+
+impl<Ms> From<ShouldRender> for Update<Ms> {
+    fn from(should_render: ShouldRender) -> Self {
+        Self { should_render, effect_msg: None }
+    }
+}
+
+impl<Ms> Default for Update<Ms> {
+    fn default() -> Self {
+        Self::from(ShouldRender::Render)
+    }
+}
+
+impl<Ms> Update<Ms> {
+    pub fn with_msg(effect_msg: Ms) -> Self {
+        Self { effect_msg: Some(effect_msg), ..Default::default() }
+    }
+
+    /// Modify this Update to skip rendering
+    pub fn skip(mut self) -> Self {
+        self.should_render = ShouldRender::Skip;
+        self
+    }
 }
 
 
@@ -241,19 +277,6 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
         self
     }
 
-    /// Do the actual self.cfg.update call. Updates self.data.model and returns (should_render, effect_msg)
-    fn call_update(&self, message: Ms) -> (bool, Option<Ms>) {
-        let update = (self.cfg.update)(message, &mut self.data.model.borrow_mut());
-
-        match update {
-            Update::Render => (true, None),
-
-            Update::Skip => (false, None),
-
-            Update::RenderThen(msg) => (true, Some(msg)),
-        }
-    }
-
     /// This runs whenever the state is changed, ie the user-written update function is called.
     /// It updates the state, and any DOM elements affected by this change.
     /// todo this is where we need to compare against differences and only update nodes affected
@@ -270,7 +293,10 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
             (l)(&message)
         }
 
-        let (should_render, effect_msg) = self.call_update(message);
+        let Update {
+            should_render,
+            effect_msg,
+        } = (self.cfg.update)(message, &mut self.data.model.borrow_mut());
 
         let model = self.data.model.borrow();
 
@@ -286,7 +312,7 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
             self.data.window_listeners.replace(new_listeners);
         }
 
-        if should_render {
+        if should_render == ShouldRender::Render {
             // Create a new vdom: The top element, and all its children. Does not yet
             // have associated web_sys elements.
             let mut topel_new_vdom = (self.cfg.view)(self.clone(), &model);

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -298,10 +298,8 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
             effect_msg,
         } = (self.cfg.update)(message, &mut self.data.model.borrow_mut());
 
-        let model = self.data.model.borrow();
-
         if let Some(window_events) = self.cfg.window_events {
-            let mut new_listeners = (window_events)(&model);
+            let mut new_listeners = (window_events)(&self.data.model.borrow());
             setup_window_listeners(
                 &util::window(),
                 &mut self.data.window_listeners.borrow_mut(),
@@ -315,7 +313,7 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
         if should_render == ShouldRender::Render {
             // Create a new vdom: The top element, and all its children. Does not yet
             // have associated web_sys elements.
-            let mut topel_new_vdom = (self.cfg.view)(self.clone(), &model);
+            let mut topel_new_vdom = (self.cfg.view)(self.clone(), &self.data.model.borrow());
 
             // We setup the vdom (which populates web_sys els through it, but don't
             // render them with attach_children; we try to do it cleverly via patch().

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -24,6 +24,7 @@ impl Default for ShouldRender {
 
 pub enum Effect<Ms> {
     Msg(Ms),
+    FutureNoMsg(Box<dyn Future<Item = (), Error = ()> + 'static>),
     FutureMsg(Box<dyn Future<Item = Ms, Error = Ms> + 'static>),
 }
 
@@ -44,6 +45,7 @@ impl<Ms> Effect<Ms> {
     {
         match self {
             Effect::Msg(msg) => Effect::Msg(f(msg)),
+            Effect::FutureNoMsg(fut) => Effect::FutureNoMsg(fut),
             Effect::FutureMsg(fut) => Effect::FutureMsg(Box::new(
                 fut.then(move |res| {
                     let res = res.map(&f).map_err(&f);
@@ -77,6 +79,15 @@ impl<Ms> Update<Ms> {
     }
 
     pub fn with_future<F>(future: F) -> Self
+    where F: Future<Item = (), Error = ()> + 'static
+    {
+        Self {
+            effect: Some(Effect::FutureNoMsg(Box::new(future))),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_future_msg<F>(future: F) -> Self
     where F: Future<Item = Ms, Error = Ms> + 'static
     {
         Self {
@@ -399,6 +410,9 @@ impl<Ms: Clone, Mdl> App<Ms, Mdl> {
         if let Some(effect) = effect {
             match effect {
                 Effect::Msg(msg) => self.update(msg),
+                Effect::FutureNoMsg(fut) => {
+                    future_to_promise(fut.then(|_res| future::ok(JsValue::UNDEFINED)));
+                },
                 Effect::FutureMsg(fut) => {
                     let self2 = self.clone();
                     future_to_promise(


### PR DESCRIPTION
My rationale for the suggested changes follows.

### Rationale for passing the model parameter by `&mut`

In my app I have a few subcomponents, so the update function for my parent component looks something like this:
```rust
match message {
  Msg::InnerComponent1(message) => {
    let Model { inner1, inner2, inner3 } = model;
    let upd = inner_module::update(message, inner1);
    wrap_update(
      upd,
      |inner1| Model { inner1, inner2, inner3 },
      |msg| Msg::InnerComponent1(msg),
    )
  }
}
```
where `wrap_update` is a helper function that matches the contents of the Update enum and converts the model part to the parent component's model using the first closure, and also converts the message part to the parent component's message type using the second closure.

Anyway, I have to unpack my Model and then put it back together so that I can pass the inner component's Model to its `update` function. I think using a mut reference might work better here. It's a bit different than the way Elm does it, but then Elm is a pure language, and doesn't have any mut references anywhere (or ownership rules, either).

With a mutable reference, it would look like this:
```rust
match message {
  Msg::InnerComponent1(message) => {
    let upd = inner_module::update(message, &mut model.inner1);
    wrap_update(upd, |msg| Msg::InnerComponent1(msg))
  }
}
```

### Rationale for making Update a struct

This is so it's easier to change the parts separately (like in my `Update::map` method, which is basically just the `wrap_update` function I mentioned earlier + support for futures). I did try to add some convenience traits/methods to make things easier, so although you can't just return `Render` any more, you can at least return `Render.into()`.

My previous example would now look like this:
```rust
match message {
  Msg::InnerComponent1(message) => {
    inner_module::update(message, &mut model.inner1)
      .map(|msg| Msg::InnerComponent1(msg))
  }
}
```

### Rationale for triggering futures in update

1. Sometimes I want to trigger a fetch request from `update` without having been called from `view` with that purpose.
2. Having to put the state in the message built in the view function gets more complicated when the message belongs to an inner component.
3. Having access to the app state in the `view` function seems a bit out of place, as does deciding on whether to put the app state inside the message or not - That would depend on whether an effect should happen, which is `update`'s job.
4. This is inspired by Elm's `Cmd` and `Task`.
