### PR TITLE
release tasks and readme badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - cargo make test_h firefox
   - cargo make test_h chrome
 
-# TODO: make it faster ; useful link
+# TODO: make it faster ; useful links:
 # https://www.reddit.com/r/rust/comments/9zpyww/idea_a_local_cache_of_compiled_dependencies_in/
 # https://doc.rust-lang.org/cargo/reference/environment-variables.html - CARGO_TARGET_DIR
 # https://github.com/holmgr/cargo-sweep

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,5 @@
 # ---- BUILD ----
+
 [tasks.build]
 description = "Build only Seed"
 clear = true
@@ -6,10 +7,20 @@ workspace = false
 command = "cargo"
 args = ["build"]
 
+[tasks.build_release]
+extend = "build"
+description = "Build only Seed in relase mode"
+args = ["build", "--release"]
+
 [tasks.all]
 description = "Build Seed and examples"
 workspace = false
 dependencies = ["build", "build_examples"]
+
+[tasks.all_release]
+extend = "all"
+description = "Build Seed and examples in release mode"
+dependencies = ["build_release", "build_examples_release"]
 
 [tasks.one]
 description = "Build Seed and chosen example. Ex: 'cargo make one counter'"
@@ -17,6 +28,12 @@ workspace = false
 command = "cargo"
 args = ["make", "--cwd", "./examples/${@}", "build"]
 dependencies = ["build"]
+
+[tasks.one_release]
+extend = "one"
+description = "Build Seed and chosen example in release mode. Ex: 'cargo make one counter'"
+args = ["make", "--cwd", "./examples/${@}", "build_release"]
+dependencies = ["build_release"]
 
 # ---- TEST ----
 
@@ -28,10 +45,20 @@ install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V
 command = "wasm-pack"
 args = ["test", "--${@}"]
 
+[tasks.test_release]
+extend = "test"
+description = "Run Seed's tests in release mode. Ex: 'cargo make test firefox'. Test envs: [chrome, firefox, safari]"
+args = ["test", "--${@}", "--release"]
+
 [tasks.test_h]
 description = "Run headless Seed's tests. Ex: 'cargo make test_h firefox'. Test envs: [chrome, firefox, safari]"
 extend = "test"
 args = ["test", "--headless", "--${@}"]
+
+[tasks.test_h_release]
+extend = "test_h"
+description = "Run headless Seed's tests in release mode. Ex: 'cargo make test_h firefox'. Test envs: [chrome, firefox, safari]"
+args = ["test", "--headless", "--${@}", "--release"]
 
 # ---- START ----
 
@@ -41,11 +68,21 @@ workspace = false
 command = "cargo"
 args = ["make", "--cwd", "./examples/${@}", "start"]
 
+[tasks.start_release]
+extend = "start"
+description = "Start chosen example in release mode. Ex: 'cargo make start counter'"
+args = ["make", "--cwd", "./examples/${@}", "start_release"]
+
 [tasks.start_server]
 description = "Start server of chosen example (only a few have one). Ex: 'cargo make start_server websocket'"
 workspace = false
 command = "cargo"
 args = ["make", "--cwd", "./examples/${@}", "start_server"]
+
+[tasks.start_server_release]
+extend = "start_server"
+description = "Start server of chosen example (only a few have one) in release mode. Ex: 'cargo make start_server websocket'"
+args = ["make", "--cwd", "./examples/${@}", "start_server_release"]
 
 # ---- DEFAULT TASKS FOR EXAMPLES ----
 # These tasks should be run only from the example root
@@ -56,7 +93,12 @@ description = "Build with wasm-pack"
 workspace = false
 install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V" }
 command = "wasm-pack"
-args = ["build", "--target", "no-modules", "--out-name", "package"]
+args = ["build", "--target", "no-modules", "--out-name", "package", "--dev"]
+
+[tasks.default_build_release]
+extend = "default_build"
+description = "Build with wasm-pack in release mode"
+args = ["build", "--target", "no-modules", "--out-name", "package", "--release"]
 
 [tasks.default_start]
 description = "Build and start microserver"
@@ -66,6 +108,11 @@ command = "microserver"
 args = ["--port", "8000"]
 dependencies = ["build"]
 
+[tasks.default_start_release]
+extend = "default_start"
+description = "Build and start microserver in release mode"
+dependencies = ["build_release"]
+
 # ---- HELPERS -----
 
 [tasks.build_examples]
@@ -73,6 +120,11 @@ description = "Build examples"
 workspace = false
 command = "cargo"
 args = ["make", "for_each", "build"]
+
+[tasks.build_examples_release]
+extend = "build_examples"
+description = "Build examples in release mode"
+args = ["make", "for_each", "build_release"]
 
 [tasks.for_each]
 description = "Run chosen task for each example in its root. Ex: 'cargo make for_each build'"
@@ -87,7 +139,6 @@ script = [
     extern crate glob;
 
     use std::process::{Command, exit, Stdio};
-    use std::io::{self, Write};
     use std::env;
     use glob::glob;
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 [![Build Status](https://travis-ci.org/David-OConnor/seed.svg?branch=master)](https://travis-ci.org/David-OConnor/seed)
+[![crates.io version](https://meritbadge.herokuapp.com/seed)](https://crates.io/crates/seed)
+[![crates.io downloads](https://img.shields.io/crates/d/seed.svg)](https://crates.io/crates/seed)
+[![docs.rs](https://docs.rs/seed/badge.svg)](https://docs.rs/seed)
 [![Built with cargo-make](https://sagiegurari.github.io/cargo-make/assets/badges/cargo-make.svg)](https://sagiegurari.github.io/cargo-make)
 
 # Quickstart

--- a/examples/counter/Makefile.toml
+++ b/examples/counter/Makefile.toml
@@ -5,7 +5,13 @@ extend = "../../Makefile.toml"
 [tasks.build]
 alias = "default_build"
 
+[tasks.build_release]
+alias = "default_build_release"
+
 # ---- START ----
 
 [tasks.start]
 alias = "default_start"
+
+[tasks.start_release]
+alias = "default_start_release"

--- a/examples/server_integration/Makefile.toml
+++ b/examples/server_integration/Makefile.toml
@@ -7,18 +7,33 @@ clear = true
 workspace = false
 dependencies = ["build_client", "build_server"]
 
+[tasks.build_release]
+extend = "build"
+description = "Build client and server in release mode"
+dependencies = ["build_client_release", "build_server_release"]
+
 [tasks.build_client]
 description = "Build client"
 workspace = false
 install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V" }
 command = "wasm-pack"
-args = ["build", "client", "--target", "no-modules", "--out-name", "package"]
+args = ["build", "client", "--target", "no-modules", "--out-name", "package", "--dev"]
+
+[tasks.build_client_release]
+extend = "build_client"
+description = "Build client in release mode"
+args = ["build", "client", "--target", "no-modules", "--out-name", "package", "--release"]
 
 [tasks.build_server]
 description = "Build server"
 workspace = false
 command = "cargo"
 args = ["build", "--package", "server"]
+
+[tasks.build_server_release]
+extend = "build_server"
+description = "Build server in release mode"
+args = ["build", "--package", "server", "--release"]
 
 # ---- START ----
 
@@ -28,3 +43,9 @@ workspace = false
 command = "cargo"
 args = ["run", "--package", "server"]
 dependencies = ["build"]
+
+[tasks.start_release]
+extend = "start"
+description = "Build and start Actix server with client on port 8000 in release mode"
+args = ["run", "--package", "server", "--release"]
+dependencies = ["build_release"]

--- a/examples/server_interaction/Makefile.toml
+++ b/examples/server_interaction/Makefile.toml
@@ -5,7 +5,13 @@ extend = "../../Makefile.toml"
 [tasks.build]
 alias = "default_build"
 
+[tasks.build_release]
+alias = "default_build_release"
+
 # ---- START ----
 
 [tasks.start]
 alias = "default_start"
+
+[tasks.start_release]
+alias = "default_start_release"

--- a/examples/todomvc/Makefile.toml
+++ b/examples/todomvc/Makefile.toml
@@ -5,7 +5,13 @@ extend = "../../Makefile.toml"
 [tasks.build]
 alias = "default_build"
 
+[tasks.build_release]
+alias = "default_build_release"
+
 # ---- START ----
 
 [tasks.start]
 alias = "default_start"
+
+[tasks.start_release]
+alias = "default_start_release"

--- a/examples/websocket/Makefile.toml
+++ b/examples/websocket/Makefile.toml
@@ -7,6 +7,11 @@ description = "Build client and server"
 clear = true
 dependencies = ["build_client", "build_server"]
 
+[tasks.build_release]
+extend = "build"
+description = "Build client and server in release mode"
+dependencies = ["build_client_release", "build_server_release"]
+
 [tasks.build_client]
 description = "Build client"
 install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V" }
@@ -15,6 +20,19 @@ args = [
     "build",
     "--target", "no-modules",
     "--out-name", "package",
+    "--dev",
+    "--",
+    "--features", "client"
+]
+
+[tasks.build_client_release]
+extend = "build_client"
+description = "Build client in release mode"
+args = [
+    "build",
+    "--target", "no-modules",
+    "--out-name", "package",
+    "--release",
     "--",
     "--features", "client"
 ]
@@ -24,11 +42,20 @@ description = "Build server"
 command = "cargo"
 args = ["build", "--bin", "server", "--features", "server"]
 
+[tasks.build_server_release]
+extend = "build_server"
+description = "Build server in release mode"
+args = ["build", "--bin", "server", "--features", "server", "--release"]
+
 # ---- START ----
 
 [tasks.start]
 alias = "default_start"
 dependencies = ["build_client"]
+
+[tasks.start_release]
+alias = "default_start_release"
+dependencies = ["build_client_release"]
 
 [tasks.start_server]
 description = "Run websocket server on port 9000"
@@ -36,4 +63,10 @@ workspace = false
 command = "cargo"
 args = ["run", "--bin", "server", "--features", "server"]
 dependencies = ["build_server"]
+
+[tasks.start_server_release]
+extend = "start_server"
+description = "Run websocket server on port 9000 in release mode"
+args = ["run", "--bin", "server", "--features", "server", "--release"]
+dependencies = ["build_server_release"]
 

--- a/examples/window_events/Makefile.toml
+++ b/examples/window_events/Makefile.toml
@@ -5,7 +5,13 @@ extend = "../../Makefile.toml"
 [tasks.build]
 alias = "default_build"
 
+[tasks.build_release]
+alias = "default_build_release"
+
 # ---- START ----
 
 [tasks.start]
 alias = "default_start"
+
+[tasks.start_release]
+alias = "default_start_release"


### PR DESCRIPTION
I found out that `wasm-pack build` builds in dev mode [by default](https://rustwasm.github.io/wasm-pack/book/commands/build.html#profile). So I've fixed it and written `*_release` tasks.
If dev mode is enough in CI, building will be 2x faster.

I've also added more badges into `README.md`.