### PR TITLE
resolved todos in server_integration examples, macro empty!

### DIFF
--- a/examples/server_integration/client/src/example_a.rs
+++ b/examples/server_integration/client/src/example_a.rs
@@ -59,14 +59,12 @@ fn send_request(new_message: String) -> impl Future<Item=Msg, Error=Msg> {
 
 pub fn view(model: &Model) -> impl ElContainer<Msg> {
     let message = match &model.response_result {
-        //@TODO: [BUG] div![] cannot be `seed::empty()` because of order bug (rewrite after fix)
-        None => div![],
+        None => empty![],
         Some(response_result) => {
             match response_result {
                 Err(fail_reason) => {
                     log!("Example_A error:", fail_reason);
-                    //@TODO: [BUG] it cannot be `seed::empty()` because of order bug (rewrite after fix)
-                    div![]
+                    empty![]
                 }
                 Ok(response) => {
                     div![

--- a/examples/server_integration/client/src/example_b.rs
+++ b/examples/server_integration/client/src/example_b.rs
@@ -56,14 +56,12 @@ fn send_request() -> impl Future<Item=Msg, Error=Msg> {
 pub fn view(model: &Model) -> impl ElContainer<Msg> {
     vec![
         match &model.fetch_result {
-            //@TODO: [BUG] it cannot be `seed::empty()` because of order bug (rewrite after fix)
-            None => div![],
+            None => empty![],
             Some(result) => {
                 match result {
                     Err(request_error) => {
                         log!("Example_B error:", request_error);
-                        //@TODO: [BUG] it cannot be `seed::empty()` because of order bug (rewrite after fix)
-                        div![]
+                        empty![]
                     }
                     Ok(response_with_data_result) => {
                         div![

--- a/examples/server_integration/client/src/example_c.rs
+++ b/examples/server_integration/client/src/example_c.rs
@@ -109,8 +109,7 @@ pub fn view(model: &Model) -> impl ElContainer<Msg> {
 
 fn view_response_result(response_result: &Option<fetch::ResponseResult<String>>) -> El<Msg> {
     match &response_result {
-        //@TODO: [BUG] it cannot be `seed::empty()` because of order bug (rewrite after fix)
-        None => div![],
+        None => empty![],
         Some(response_result) => {
             match response_result {
                 Err(fail_reason) => view_fail_reason(fail_reason),
@@ -135,8 +134,7 @@ fn view_fail_reason(fail_reason: &fetch::FailReason) -> El<Msg> {
         }
     }
     log!("Example_C error:", fail_reason);
-    //@TODO: [BUG] it cannot be `seed::empty()` because of order bug (rewrite after fix)
-    div![]
+    empty![]
 }
 
 

--- a/examples/server_integration/client/src/example_d.rs
+++ b/examples/server_integration/client/src/example_d.rs
@@ -88,13 +88,10 @@ pub fn view(model: &Model) -> impl ElContainer<Msg> {
     match &model.response_result {
         None => {
             vec![
-                //@TODO: [BUG] if you comment out div with info (only button remains),
-                //       button disappears when request ends
                 if let Status::WaitingForResponse(_) = model.status {
                     div!["Waiting for response..."]
                 } else {
-                    //@TODO: [BUG] it cannot be `seed::empty()` because of order bug (rewrite after fix)
-                    div![]
+                    empty![]
                 },
                 view_button(&model.status)
             ]

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -10,7 +10,7 @@ macro_rules! with_dollar_sign {
 }
 
 /// Create macros exposed to the package that allow shortcuts for Dom elements.
-/// In the matching mattern below, we match the name we want to use with the name under
+/// In the matching pattern below, we match the name we want to use with the name under
 /// the seed::dom_types::Tag enum. Eg the div! macro uses seed::dom_types::Tag::Div.
 macro_rules! element {
     // Create shortcut macros for any element; populate these functions in this module.
@@ -146,6 +146,11 @@ element_svg! {
 //  - meshrow
 //  - style
 //  - view
+
+#[macro_export]
+macro_rules! empty {
+    () => { seed::empty() }
+}
 
 #[macro_export]
 macro_rules! custom {
@@ -317,7 +322,7 @@ macro_rules! error {
      };
 }
 
-/// A HashMap literal, where the keys and valsmust implement ToString.
+/// A HashMap literal, where the keys and values must implement ToString.
 #[macro_export]
 macro_rules! hashmap_string {
     { $($key:expr => $value:expr),* $(,)* } => {


### PR DESCRIPTION
- New macro `empty!` - I think it's a little bit more readable than `seed::empty()` and more consistent with other DOM elements, so it should be clear on the first look that it represents an `El`.

- Todos could be resolved thanks to your correcting of root elements behavior (#119).

- Some typos fixed.