### PR TITLE
125-check-style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
 
 script:
   - cargo install --force cargo-make # remove --force in the future (https://github.com/rust-lang/cargo/pull/6798)
+  - cargo make fmt_all_check
+  - cargo make clippy_all
   - cargo make all
   - cargo make test_h firefox
   - cargo make test_h chrome

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,3 +1,8 @@
+[env]
+# Reset rustup recursion limit because otherwise `cargo make clippy_all` fails.
+# https://github.com/rust-lang/rustup.rs/blob/d35f94183601a81489bce025c2abc35cd395c909/src/toolchain.rs#L296
+RUST_RECURSION_COUNT = "0"
+
 # ---- BUILD ----
 
 [tasks.build]
@@ -41,6 +46,19 @@ dependencies = ["build_release"]
 description = "Format Seed and all examples with rustfmt"
 workspace = false
 dependencies = ["fmt", "fmt_examples"]
+
+[tasks.clippy]
+description = "Lint only Seed with Clippy"
+clear = true
+workspace = false
+install_crate = { rustup_component_name = "clippy", binary = "cargo-clippy", test_arg = "--help" }
+command = "cargo"
+args = ["clippy", "--all-features", "--", "--deny", "clippy::all", "--deny", "clippy::pedantic", "--deny", "clippy::nursery"]
+
+[tasks.clippy_all]
+description = "Lint Seed and all examples with Clippy"
+workspace = false
+dependencies = ["clippy", "clippy_examples"]
 
 # ---- TEST ----
 
@@ -153,9 +171,9 @@ description = "Build examples in release mode"
 args = ["make", "for_each", "build_release"]
 
 [tasks.fmt]
-description = "Format Seed and examples in workspace with rustfmt"
+description = "Format with rustfmt --all"
 workspace = false
-install_crate = "rustfmt"
+install_crate = { crate_name = "rustfmt-nightly", rustup_component_name = "rustfmt", binary = "rustfmt", test_arg = "--help" }
 command = "cargo"
 args = ["fmt", "--all"]
 
@@ -164,6 +182,12 @@ description = "Format all examples with rustfmt"
 workspace = false
 command = "cargo"
 args = ["make", "for_each", "fmt"]
+
+[tasks.clippy_examples]
+description = "Lint examples with Clippy"
+workspace = false
+command = "cargo"
+args = ["make", "for_each", "clippy"]
 
 [tasks.for_each]
 description = "Run chosen task for each example in its root. Ex: 'cargo make for_each build'"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -40,7 +40,7 @@ description = "Build Seed and chosen example in release mode. Ex: 'cargo make on
 args = ["make", "--cwd", "./examples/${@}", "build_release"]
 dependencies = ["build_release"]
 
-# ---- LINTERS ----
+# ---- LINT ----
 
 [tasks.fmt_all]
 description = "Format Seed and all examples with rustfmt"
@@ -53,7 +53,14 @@ clear = true
 workspace = false
 install_crate = { rustup_component_name = "clippy", binary = "cargo-clippy", test_arg = "--help" }
 command = "cargo"
-args = ["clippy", "--all-features", "--", "--deny", "clippy::all", "--deny", "clippy::pedantic", "--deny", "clippy::nursery"]
+args = ["clippy", "--all-features", "--", "--deny", "warnings", "--deny", "clippy::pedantic", "--deny", "clippy::nursery"]
+
+[tasks.clippy_one]
+description = "Lint Seed and chosen example with Clippy. Ex: 'cargo make clippy_one counter'"
+workspace = false
+command = "cargo"
+args = ["make", "--cwd", "./examples/${@}", "clippy"]
+dependencies = ["clippy"]
 
 [tasks.clippy_all]
 description = "Lint Seed and all examples with Clippy"
@@ -156,6 +163,13 @@ dependencies = ["build"]
 extend = "default_start"
 description = "Build and start microserver in release mode"
 dependencies = ["build_release"]
+
+[tasks.default_clippy]
+description = "Lint with Clippy"
+workspace = false
+install_crate = { rustup_component_name = "clippy", binary = "cargo-clippy", test_arg = "--help" }
+command = "cargo"
+args = ["clippy", "--all-features", "--", "--deny", "warnings", "--deny", "clippy::pedantic", "--deny", "clippy::nursery"]
 
 # ---- HELPERS -----
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -35,6 +35,13 @@ description = "Build Seed and chosen example in release mode. Ex: 'cargo make on
 args = ["make", "--cwd", "./examples/${@}", "build_release"]
 dependencies = ["build_release"]
 
+# ---- LINTERS ----
+
+[tasks.fmt_all]
+description = "Format Seed and all examples with rustfmt"
+workspace = false
+dependencies = ["fmt", "fmt_examples"]
+
 # ---- TEST ----
 
 # wasm-pack test docs:
@@ -145,6 +152,19 @@ extend = "build_examples"
 description = "Build examples in release mode"
 args = ["make", "for_each", "build_release"]
 
+[tasks.fmt]
+description = "Format Seed and examples in workspace with rustfmt"
+workspace = false
+install_crate = "rustfmt"
+command = "cargo"
+args = ["fmt", "--all"]
+
+[tasks.fmt_examples]
+description = "Format all examples with rustfmt"
+workspace = false
+command = "cargo"
+args = ["make", "for_each", "fmt"]
+
 [tasks.for_each]
 description = "Run chosen task for each example in its root. Ex: 'cargo make for_each build'"
 workspace = false
@@ -179,6 +199,7 @@ script = [
     }
 
     fn run_task_in_example_root(example_root: &str, task: &str) {
+        println!("Example root: '{}'", example_root);
         Command::new("cargo")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -47,6 +47,11 @@ description = "Format Seed and all examples with rustfmt"
 workspace = false
 dependencies = ["fmt", "fmt_examples"]
 
+[tasks.fmt_all_check]
+description = "Check format of Seed and all examples with rustfmt"
+workspace = false
+dependencies = ["fmt_check", "fmt_examples_check"]
+
 [tasks.clippy]
 description = "Lint only Seed with Clippy"
 clear = true
@@ -185,17 +190,28 @@ description = "Build examples in release mode"
 args = ["make", "for_each", "build_release"]
 
 [tasks.fmt]
-description = "Format with rustfmt --all"
+description = "Format with rustfmt"
 workspace = false
 install_crate = { crate_name = "rustfmt-nightly", rustup_component_name = "rustfmt", binary = "rustfmt", test_arg = "--help" }
 command = "cargo"
 args = ["fmt", "--all"]
+
+[tasks.fmt_check]
+extend = "fmt"
+description = "Check format with rustfmt"
+args = ["fmt", "--all", "--", "--check"]
 
 [tasks.fmt_examples]
 description = "Format all examples with rustfmt"
 workspace = false
 command = "cargo"
 args = ["make", "for_each", "fmt"]
+
+[tasks.fmt_examples_check]
+description = "Check format of all examples with rustfmt"
+workspace = false
+command = "cargo"
+args = ["make", "for_each", "fmt_check"]
 
 [tasks.clippy_examples]
 description = "Lint examples with Clippy"
@@ -226,24 +242,31 @@ script = [
             eprintln!("Wrong number of arguments! Correct example: 'cargo make for_each build'");
             exit(1);
         }
+
         let task = &args[1];
+        let mut exit_code = 0;
 
         for entry in glob("examples/*/Makefile.toml").unwrap() {
             if let Ok(path) = entry {
                 let example_root = path.parent().unwrap().to_str().unwrap();
-                run_task_in_example_root(example_root, task);
+                if !run_task_in_example_root(example_root, task) {
+                    exit_code = 1;
+                }
             }
         }
+        exit(exit_code);
     }
 
-    fn run_task_in_example_root(example_root: &str, task: &str) {
+    fn run_task_in_example_root(example_root: &str, task: &str) -> bool {
         println!("Example root: '{}'", example_root);
         Command::new("cargo")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .args(&["make", "--cwd", example_root, task])
             .output()
-            .unwrap();
+            .unwrap()
+            .status
+            .success()
     }
     '''
 ]

--- a/examples/animation_frame/Makefile.toml
+++ b/examples/animation_frame/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/counter/Makefile.toml
+++ b/examples/counter/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -1,5 +1,7 @@
 //! A simple, cliché example demonstrating structure and syntax.
 
+#![allow(clippy::non_ascii_literal)]
+
 #[macro_use]
 extern crate seed;
 
@@ -54,7 +56,7 @@ fn success_level(clicks: i32) -> El<Msg> {
 }
 
 /// The top-level component we pass to the virtual dom. Must accept the model as its
-/// only argument, and output has to implement trait ElContainer.
+/// only argument, and output has to implement trait `ElContainer`.
 fn view(model: &Model) -> El<Msg> {
     let plural = if model.count == 1 { "" } else { "s" };
     let text = format!("{} {}{} so far", model.count, model.what_we_count, plural);

--- a/examples/mathjax/Makefile.toml
+++ b/examples/mathjax/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::non_ascii_literal)]
+
 #[macro_use]
 extern crate seed;
 use seed::prelude::*;
@@ -14,13 +16,10 @@ impl Default for Model {
     }
 }
 
-// Update
+// Msg
 
 #[derive(Clone)]
-enum Msg {}
-
-fn update(msg: Msg, model: &mut Model, _orders: &mut Orders<Msg>) {
-}
+struct Msg;
 
 // View
 
@@ -30,10 +29,13 @@ fn definition(description: &str, def: &str) -> El<Msg> {
 }
 
 fn _dirac_3(left: &str, middle: &str, right: &str) -> String {
-    format!(r"\langle {} \lvert {} \rvert {} \rangle", left, middle, right)
+    format!(
+        r"\langle {} \lvert {} \rvert {} \rangle",
+        left, middle, right
+    )
 }
 
-fn view(model: &Model) -> Vec<El<Msg>> {
+fn view(_: &Model) -> Vec<El<Msg>> {
     vec![
         h1!["Linear algebra cheatsheet"],
         p!["Intent: Provide a quick reference of definitions and identities that 
@@ -182,7 +184,7 @@ e^{-\mathbf{A}} = \mathbf{B} + [\mathbf{A}, \mathbf{B}]"
 
 #[wasm_bindgen]
 pub fn render() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(Model::default(), |_, _, _| (), view)
         .finish()
         .run();
 }

--- a/examples/orders/Makefile.toml
+++ b/examples/orders/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::non_ascii_literal)]
+
 #[macro_use]
 extern crate seed;
 

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.1.0 (git+https://github.com/rustwasm/gloo)",
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/examples/server_integration/Makefile.toml
+++ b/examples/server_integration/Makefile.toml
@@ -53,11 +53,16 @@ dependencies = ["build_release"]
 # ---- LINT ----
 
 [tasks.fmt]
-description = "Format with rustfmt --all"
+description = "Format with rustfmt"
 workspace = false
 install_crate = { crate_name = "rustfmt-nightly", rustup_component_name = "rustfmt", binary = "rustfmt", test_arg = "--help" }
 command = "cargo"
 args = ["fmt", "--all"]
+
+[tasks.fmt_check]
+extend = "fmt"
+description = "Check format with rustfmt"
+args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
 description = "Lint with Clippy"

--- a/examples/server_integration/Makefile.toml
+++ b/examples/server_integration/Makefile.toml
@@ -49,3 +49,12 @@ extend = "start"
 description = "Build and start Actix server with client on port 8000 in release mode"
 args = ["run", "--package", "server", "--release"]
 dependencies = ["build_release"]
+
+# ---- LINTERS ----
+
+[tasks.fmt]
+description = "Format with rustfmt"
+workspace = false
+install_crate = "rustfmt"
+command = "cargo"
+args = ["fmt", "--all"]

--- a/examples/server_integration/Makefile.toml
+++ b/examples/server_integration/Makefile.toml
@@ -53,8 +53,16 @@ dependencies = ["build_release"]
 # ---- LINTERS ----
 
 [tasks.fmt]
-description = "Format with rustfmt"
+description = "Format with rustfmt --all"
 workspace = false
-install_crate = "rustfmt"
+install_crate = { crate_name = "rustfmt-nightly", rustup_component_name = "rustfmt", binary = "rustfmt", test_arg = "--help" }
 command = "cargo"
 args = ["fmt", "--all"]
+
+[tasks.clippy]
+description = "Lint with Clippy"
+clear = true
+workspace = false
+install_crate = { rustup_component_name = "clippy", binary = "cargo-clippy", test_arg = "--help" }
+command = "cargo"
+args = ["clippy", "--all-features", "--", "--deny", "clippy::all", "--deny", "clippy::pedantic", "--deny", "clippy::nursery"]

--- a/examples/server_integration/Makefile.toml
+++ b/examples/server_integration/Makefile.toml
@@ -50,7 +50,7 @@ description = "Build and start Actix server with client on port 8000 in release 
 args = ["run", "--package", "server", "--release"]
 dependencies = ["build_release"]
 
-# ---- LINTERS ----
+# ---- LINT ----
 
 [tasks.fmt]
 description = "Format with rustfmt --all"

--- a/examples/server_integration/client/src/example_a.rs
+++ b/examples/server_integration/client/src/example_a.rs
@@ -1,12 +1,11 @@
-use seed::prelude::*;
-use seed::fetch;
 use futures::Future;
+use seed::fetch;
+use seed::prelude::*;
 
 use shared;
 
 pub const TITLE: &str = "Example A";
-pub const DESCRIPTION: &str =
-    "Write something into input and click on 'Send message'.
+pub const DESCRIPTION: &str = "Write something into input and click on 'Send message'.
     Message will be send to server and then it wil be returned with ordinal number.
     Ordinal number is incremented by server with each request.";
 
@@ -48,7 +47,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
     }
 }
 
-fn send_request(new_message: String) -> impl Future<Item=Msg, Error=Msg> {
+fn send_request(new_message: String) -> impl Future<Item = Msg, Error = Msg> {
     fetch::Request::new(get_request_url())
         .method(fetch::Method::Post)
         .send_json(&shared::SendMessageRequestBody { text: new_message })
@@ -60,30 +59,24 @@ fn send_request(new_message: String) -> impl Future<Item=Msg, Error=Msg> {
 pub fn view(model: &Model) -> impl ElContainer<Msg> {
     let message = match &model.response_result {
         None => empty![],
-        Some(response_result) => {
-            match response_result {
-                Err(fail_reason) => {
-                    log!("Example_A error:", fail_reason);
-                    empty![]
-                }
-                Ok(response) => {
-                    div![
-                        format!(r#"{}. message: "{}""#, response.data.ordinal_number, response.data.text)
-                    ]
-                }
+        Some(response_result) => match response_result {
+            Err(fail_reason) => {
+                log!("Example_A error:", fail_reason);
+                empty![]
             }
-        }
+            Ok(response) => div![format!(
+                r#"{}. message: "{}""#,
+                response.data.ordinal_number, response.data.text
+            )],
+        },
     };
 
     vec![
         message,
         input![
             input_ev(Ev::Input, Msg::NewMessageChanged),
-            attrs!{At::Value => model.new_message}
+            attrs! {At::Value => model.new_message}
         ],
-        button![
-            simple_ev(Ev::Click, Msg::SendRequest),
-            "Send message"
-        ],
+        button![simple_ev(Ev::Click, Msg::SendRequest), "Send message"],
     ]
 }

--- a/examples/server_integration/client/src/example_b.rs
+++ b/examples/server_integration/client/src/example_b.rs
@@ -1,6 +1,6 @@
-use seed::prelude::*;
-use seed::fetch;
 use futures::Future;
+use seed::fetch;
+use seed::prelude::*;
 use serde::Deserialize;
 
 pub const TITLE: &str = "Example B";
@@ -21,7 +21,7 @@ pub struct Model {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ExpectedResponseData {
-    something: String
+    something: String,
 }
 
 // Update
@@ -35,9 +35,7 @@ pub enum Msg {
 pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
     match msg {
         Msg::SendRequest => {
-            orders
-                .skip()
-                .perform_cmd(send_request());
+            orders.skip().perform_cmd(send_request());
         }
 
         Msg::Fetched(fetch_object) => {
@@ -46,9 +44,8 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
     }
 }
 
-fn send_request() -> impl Future<Item=Msg, Error=Msg> {
-    fetch::Request::new(get_request_url())
-        .fetch_json(Msg::Fetched)
+fn send_request() -> impl Future<Item = Msg, Error = Msg> {
+    fetch::Request::new(get_request_url()).fetch_json(Msg::Fetched)
 }
 
 // View
@@ -57,25 +54,24 @@ pub fn view(model: &Model) -> impl ElContainer<Msg> {
     vec![
         match &model.fetch_result {
             None => empty![],
-            Some(result) => {
-                match result {
-                    Err(request_error) => {
-                        log!("Example_B error:", request_error);
-                        empty![]
-                    }
-                    Ok(response_with_data_result) => {
-                        div![
-                            div![format!("Status code: {}", response_with_data_result.status.code)],
-                            div![format!(r#"Status text: "{}""#, response_with_data_result.status.text)],
-                            div![format!(r#"Data: "{:#?}""#, response_with_data_result.data)]
-                        ]
-                    }
+            Some(result) => match result {
+                Err(request_error) => {
+                    log!("Example_B error:", request_error);
+                    empty![]
                 }
-            }
+                Ok(response_with_data_result) => div![
+                    div![format!(
+                        "Status code: {}",
+                        response_with_data_result.status.code
+                    )],
+                    div![format!(
+                        r#"Status text: "{}""#,
+                        response_with_data_result.status.text
+                    )],
+                    div![format!(r#"Data: "{:#?}""#, response_with_data_result.data)]
+                ],
+            },
         },
-        button![
-            simple_ev(Ev::Click, Msg::SendRequest),
-            "Try to Fetch JSON"
-        ],
+        button![simple_ev(Ev::Click, Msg::SendRequest), "Try to Fetch JSON"],
     ]
 }

--- a/examples/server_integration/client/src/example_c.rs
+++ b/examples/server_integration/client/src/example_c.rs
@@ -1,6 +1,6 @@
-use seed::prelude::*;
-use seed::fetch;
 use futures::Future;
+use seed::fetch;
+use seed::prelude::*;
 
 pub const TITLE: &str = "Example C";
 pub const DESCRIPTION: &str =
@@ -47,13 +47,15 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
         Msg::SendRequest => {
             model.status = Status::WaitingForResponse;
             model.response_result = None;
-            orders
-                .perform_cmd(send_request(&mut model.request_controller));
+            orders.perform_cmd(send_request(&mut model.request_controller));
         }
 
         Msg::AbortRequest => {
-            model.request_controller
-                .take().expect("AbortRequest: request_controller hasn't been set!").abort();
+            model
+                .request_controller
+                .take()
+                .expect("AbortRequest: request_controller hasn't been set!")
+                .abort();
             model.status = Status::RequestAborted;
         }
 
@@ -65,9 +67,8 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
 }
 
 fn send_request(
-    request_controller: &mut Option<fetch::RequestController>
-) -> impl Future<Item=Msg, Error=Msg>
-{
+    request_controller: &mut Option<fetch::RequestController>,
+) -> impl Future<Item = Msg, Error = Msg> {
     fetch::Request::new(get_request_url())
         .controller(|controller| *request_controller = Some(controller))
         .fetch_string(Msg::Fetched)
@@ -77,69 +78,42 @@ fn send_request(
 
 pub fn view(model: &Model) -> impl ElContainer<Msg> {
     match model.status {
-        Status::ReadyToSendRequest => {
-            vec![
-                view_response_result(&model.response_result),
-                button![
-                    simple_ev(Ev::Click, Msg::SendRequest),
-                    "Send request"
-                ]
-            ]
-        }
-        Status::WaitingForResponse => {
-            vec![
-                div!["Waiting for response..."],
-                button![
-                    simple_ev(Ev::Click, Msg::AbortRequest),
-                    "Abort request"
-                ]
-            ]
-        }
-        Status::RequestAborted => {
-            vec![
-                view_response_result(&model.response_result),
-                button![
-                    attrs!{At::Disabled => false},
-                    "Request aborted"
-                ]
-            ]
-        }
+        Status::ReadyToSendRequest => vec![
+            view_response_result(&model.response_result),
+            button![simple_ev(Ev::Click, Msg::SendRequest), "Send request"],
+        ],
+        Status::WaitingForResponse => vec![
+            div!["Waiting for response..."],
+            button![simple_ev(Ev::Click, Msg::AbortRequest), "Abort request"],
+        ],
+        Status::RequestAborted => vec![
+            view_response_result(&model.response_result),
+            button![attrs! {At::Disabled => false}, "Request aborted"],
+        ],
     }
 }
 
 fn view_response_result(response_result: &Option<fetch::ResponseResult<String>>) -> El<Msg> {
     match &response_result {
         None => empty![],
-        Some(response_result) => {
-            match response_result {
-                Err(fail_reason) => view_fail_reason(fail_reason),
-                Ok(response) => {
-                    div![format!(r#"Response String body: "{}""#, response.data)]
-                }
-            }
-        }
+        Some(response_result) => match response_result {
+            Err(fail_reason) => view_fail_reason(fail_reason),
+            Ok(response) => div![format!(r#"Response String body: "{}""#, response.data)],
+        },
     }
 }
 
 fn view_fail_reason(fail_reason: &fetch::FailReason) -> El<Msg> {
-    if let fetch::FailReason::RequestError(
-        fetch::RequestError::DomException(dom_exception)
-    ) = fail_reason {
+    if let fetch::FailReason::RequestError(fetch::RequestError::DomException(dom_exception)) =
+        fail_reason
+    {
         if dom_exception.name() == "AbortError" {
-            return
-                div![
-                    div![format!(r#"Error name: "{}""#, dom_exception.name())],
-                    div![format!(r#"Error message: "{}""#, dom_exception.message())]
-                ];
+            return div![
+                div![format!(r#"Error name: "{}""#, dom_exception.name())],
+                div![format!(r#"Error message: "{}""#, dom_exception.message())]
+            ];
         }
     }
     log!("Example_C error:", fail_reason);
     empty![]
 }
-
-
-
-
-
-
-

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -55,20 +55,31 @@ fn view(model: &Model) -> impl ElContainer<Msg> {
     let examples = vec![
         // example_a
         view_example_introduction(example_a::TITLE, example_a::DESCRIPTION),
-        example_a::view(&model.example_a).els().map_message(Msg::ExampleA),
+        example_a::view(&model.example_a)
+            .els()
+            .map_message(Msg::ExampleA),
         // example_b
         view_example_introduction(example_b::TITLE, example_b::DESCRIPTION),
-        example_b::view(&model.example_b).els().map_message(Msg::ExampleB),
+        example_b::view(&model.example_b)
+            .els()
+            .map_message(Msg::ExampleB),
         // example_c
         view_example_introduction(example_c::TITLE, example_c::DESCRIPTION),
-        example_c::view(&model.example_c).els().map_message(Msg::ExampleC),
+        example_c::view(&model.example_c)
+            .els()
+            .map_message(Msg::ExampleC),
         // example_d
         view_example_introduction(example_d::TITLE, example_d::DESCRIPTION),
-        example_d::view(&model.example_d).els().map_message(Msg::ExampleD),
-    ].into_iter().flatten().collect::<Vec<El<Msg>>>();
+        example_d::view(&model.example_d)
+            .els()
+            .map_message(Msg::ExampleD),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<El<Msg>>>();
 
     div![
-        style!{
+        style! {
             "font-family" => "sans-serif";
             "max-width" => 460;
             "margin" => "auto";
@@ -81,10 +92,7 @@ fn view_example_introduction(title: &str, description: &str) -> Vec<El<Msg>> {
     vec![
         hr![],
         h2![title],
-        div![
-            style!{"margin-bottom" => 15;},
-            description
-        ]
+        div![style! {"margin-bottom" => 15;}, description],
     ]
 }
 

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::enum_variant_names, clippy::large_enum_variant)]
+
 #[macro_use]
 extern crate seed;
 

--- a/examples/server_integration/server/src/main.rs
+++ b/examples/server_integration/server/src/main.rs
@@ -1,5 +1,5 @@
-use actix_web::{get, post, HttpServer, App, Responder, web, HttpResponse};
 use actix_files::{Files, NamedFile};
+use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
 use std::sync::{Arc, Mutex};
 use std::{thread, time};
 
@@ -14,7 +14,7 @@ type State = Arc<Mutex<StateData>>;
 
 #[derive(Default)]
 struct StateData {
-    message_ordinal_number: u32
+    message_ordinal_number: u32,
 }
 
 #[post("/api/send-message")]
@@ -23,12 +23,10 @@ fn send_message(
     request_data: web::Json<shared::SendMessageRequestBody>,
 ) -> impl Responder {
     state.lock().unwrap().message_ordinal_number += 1;
-    web::Json(
-        shared::SendMessageResponseBody {
-            ordinal_number: state.lock().unwrap().message_ordinal_number,
-            text: request_data.text.clone(),
-        }
-    )
+    web::Json(shared::SendMessageResponseBody {
+        ordinal_number: state.lock().unwrap().message_ordinal_number,
+        text: request_data.text.clone(),
+    })
 }
 
 #[get("/api/delayed-response/{delay}")]
@@ -60,7 +58,6 @@ fn main() -> std::io::Result<()> {
             .service(Files::new("/pkg", "./client/pkg"))
             .service(index)
     })
-        .bind("127.0.0.1:8000")?
-        .run()
+    .bind("127.0.0.1:8000")?
+    .run()
 }
-

--- a/examples/server_integration/shared/src/lib.rs
+++ b/examples/server_integration/shared/src/lib.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SendMessageRequestBody {

--- a/examples/server_interaction/Makefile.toml
+++ b/examples/server_interaction/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -1,5 +1,7 @@
-//! https://rustwasm.github.io/wasm-bindgen/examples/fetch.html
-//! https://serde.rs/
+//! [https://rustwasm.github.io/wasm-bindgen/examples/fetch.html](https://rustwasm.github.io/wasm-bindgen/examples/fetch.html)
+//! [https://serde.rs/](https://serde.rs/)
+
+#![allow(clippy::large_enum_variant)]
 
 #[macro_use]
 extern crate seed;

--- a/examples/server_interaction_detailed/Makefile.toml
+++ b/examples/server_interaction_detailed/Makefile.toml
@@ -101,3 +101,12 @@ workspace = false
 install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V" }
 command = "wasm-pack"
 args = ["test", "--firefox", "--headless", "--", "--lib", "${@}"]
+
+# ---- LINTERS ----
+
+[tasks.fmt]
+description = "Format with rustfmt"
+workspace = false
+install_crate = "rustfmt"
+command = "cargo"
+args = ["fmt", "--all"]

--- a/examples/server_interaction_detailed/Makefile.toml
+++ b/examples/server_interaction_detailed/Makefile.toml
@@ -105,11 +105,16 @@ args = ["test", "--firefox", "--headless", "--", "--lib", "${@}"]
 # ---- LINT ----
 
 [tasks.fmt]
-description = "Format with rustfmt --all"
+description = "Format with rustfmt"
 workspace = false
 install_crate = { crate_name = "rustfmt-nightly", rustup_component_name = "rustfmt", binary = "rustfmt", test_arg = "--help" }
 command = "cargo"
 args = ["fmt", "--all"]
+
+[tasks.fmt_check]
+extend = "fmt"
+description = "Check format with rustfmt"
+args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
 description = "Lint with Clippy"

--- a/examples/server_interaction_detailed/Makefile.toml
+++ b/examples/server_interaction_detailed/Makefile.toml
@@ -105,8 +105,16 @@ args = ["test", "--firefox", "--headless", "--", "--lib", "${@}"]
 # ---- LINTERS ----
 
 [tasks.fmt]
-description = "Format with rustfmt"
+description = "Format with rustfmt --all"
 workspace = false
-install_crate = "rustfmt"
+install_crate = { crate_name = "rustfmt-nightly", rustup_component_name = "rustfmt", binary = "rustfmt", test_arg = "--help" }
 command = "cargo"
 args = ["fmt", "--all"]
+
+[tasks.clippy]
+description = "Lint with Clippy"
+clear = true
+workspace = false
+install_crate = { rustup_component_name = "clippy", binary = "cargo-clippy", test_arg = "--help" }
+command = "cargo"
+args = ["clippy", "--all-features", "--", "--deny", "clippy::all", "--deny", "clippy::pedantic", "--deny", "clippy::nursery"]

--- a/examples/server_interaction_detailed/Makefile.toml
+++ b/examples/server_interaction_detailed/Makefile.toml
@@ -102,7 +102,7 @@ install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V
 command = "wasm-pack"
 args = ["test", "--firefox", "--headless", "--", "--lib", "${@}"]
 
-# ---- LINTERS ----
+# ---- LINT ----
 
 [tasks.fmt]
 description = "Format with rustfmt --all"

--- a/examples/server_interaction_detailed/me/src/lib.rs
+++ b/examples/server_interaction_detailed/me/src/lib.rs
@@ -9,9 +9,6 @@ use shared::interfaces;
 use shared::interfaces::{Gradesheet, Line, Mission, Person, Syllabus, Upgrade, UpgradeEvent};
 use shared::util;
 
-
-
-
 #[wasm_bindgen]
 pub fn render() {
     let state = seed::App::build(Model::default(), update, view)

--- a/examples/server_interaction_detailed/reports/src/lib.rs
+++ b/examples/server_interaction_detailed/reports/src/lib.rs
@@ -5,9 +5,8 @@ use seed::prelude::*;
 use futures::Future;
 use serde::Deserialize;
 
-use shared::{datetime, util};
 use shared::interfaces::{Gradesheet, Line, Mission, Person, Syllabus, Upgrade, UpgradeEvent};
-
+use shared::{datetime, util};
 
 struct Model {
     lines: Vec<Line>,
@@ -86,7 +85,7 @@ fn update(msg: Msg, model: &mut Model) -> Update<Msg> {
         }
 
         Msg::OnFetchErr(err) => {
-            log!(format!("Fetch error: {:?}", err));  // todo switch to error! once new seed version released
+            log!(format!("Fetch error: {:?}", err)); // todo switch to error! once new seed version released
             Skip.into()
         }
 
@@ -106,7 +105,11 @@ fn gradesheets(model: &Model) -> El<Msg> {
     section![]
 }
 
-fn mx_effectivity(lines: &Vec<Line>, mx_start: &datetime::Date, mx_end: &datetime::Date) -> El<Msg> {
+fn mx_effectivity(
+    lines: &Vec<Line>,
+    mx_start: &datetime::Date,
+    mx_end: &datetime::Date,
+) -> El<Msg> {
     //    let lines_filtered = lines.iter().filter(l )
     let lines_filtered = lines;
 
@@ -127,20 +130,20 @@ fn mx_effectivity(lines: &Vec<Line>, mx_start: &datetime::Date, mx_end: &datetim
     let percent = |num: usize| {
         let val = match lines_filtered.len() {
             0 => num as f32 / lines_filtered.len() as f32,
-            _ => 0.
+            _ => 0.,
         };
         (val * 100.).to_string() + &"%"
     };
 
-    let margin_style = style!{"margin-right" => 60};
+    let margin_style = style! {"margin-right" => 60};
 
     let display_block = |val: usize, title: &str| {
         div![
-                    style!{"display" => "flex"},
-                    h3![&margin_style, title],
-                    h3![&margin_style, val.to_string()],
-                    h3![percent(val)],
-                ]
+            style! {"display" => "flex"},
+            h3![&margin_style, title],
+            h3![&margin_style, val.to_string()],
+            h3![percent(val)],
+        ]
     };
 
     section![
@@ -152,8 +155,7 @@ fn mx_effectivity(lines: &Vec<Line>, mx_start: &datetime::Date, mx_end: &datetim
                 style! {"display" => "flex"; "margin-bottom" => 60},
                 h3!["Start"],
                 h3!["End"],
-                ],
-
+            ],
             display_block(eff, "Effective:"),
             display_block(ne_wx, "Non-effective weather:"),
             display_block(ne_ops, "Non-effective ops:"),
@@ -180,8 +182,6 @@ fn display_pct2<T>(len: usize, whole: &Vec<T>) -> String {
     }
 }
 
-
-
 fn sortie_types(lines: &Vec<Line>, people: &Vec<Person>, missions: &Vec<Mission>) -> El<Msg> {
     let lookback_days = 60; // todo make adjustable
     let today = datetime::Date::today();
@@ -190,7 +190,7 @@ fn sortie_types(lines: &Vec<Line>, people: &Vec<Person>, missions: &Vec<Mission>
 
     let mut rows: Vec<El<Msg>> = Vec::new();
 
-//    log!(format!("{:?}", today));
+    //    log!(format!("{:?}", today));
 
     for person in people.iter().filter(|p| util::is_aircrew(*p)) {
         // todo person_lines is much too verbose.
@@ -205,7 +205,7 @@ fn sortie_types(lines: &Vec<Line>, people: &Vec<Person>, missions: &Vec<Mission>
                     //                        .expect("Can't find pilot");
                     //                if pilot.id == person.id && min_date <= l_date && l_date <= today {
                     if let Some(pilot) = pilot {
-//                        if pilot.id == person.id {
+                        //                        if pilot.id == person.id {
                         if pilot.id == person.id && min_date <= l_date && l_date <= today {
                             return true;
                         }
@@ -217,7 +217,7 @@ fn sortie_types(lines: &Vec<Line>, people: &Vec<Person>, missions: &Vec<Mission>
                     //                        .expect("Can't find WSO");
                     //                if wso.id == person.id && min_date <= l_date && l_date <= today {
                     if let Some(wso) = wso {
-//                        if wso.id == person.id {
+                        //                        if wso.id == person.id {
                         if wso.id == person.id && min_date <= l_date && l_date <= today {
                             return true;
                         }

--- a/examples/server_interaction_detailed/src/datetime.rs
+++ b/examples/server_interaction_detailed/src/datetime.rs
@@ -3,9 +3,8 @@ use std::fmt;
 
 use chrono;
 use chrono::offset::TimeZone;
-use chrono::{Datelike};
+use chrono::Datelike;
 use js_sys;
-
 
 type Cdate = chrono::Date<chrono::Utc>;
 
@@ -81,7 +80,12 @@ impl PartialOrd for Date {
 
 impl fmt::Debug for Date {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}, {:?}", self.wrapped, self.wrapped.format("%Y-%h-%D").to_string())
+        write!(
+            f,
+            "{:?}, {:?}",
+            self.wrapped,
+            self.wrapped.format("%Y-%h-%D").to_string()
+        )
     }
 }
 
@@ -106,17 +110,15 @@ impl fmt::Debug for Date {
 //}
 
 impl From<Cdate> for Date {
-   fn from(date: Cdate) -> Self {
-       Self {
-           wrapped: date
-       }
-   }
+    fn from(date: Cdate) -> Self {
+        Self { wrapped: date }
+    }
 }
 
 impl Date {
     pub fn new(year: i32, month: u32, day: u32) -> Self {
-        Self{
-            wrapped: chrono::Utc.ymd(year, month, day)
+        Self {
+            wrapped: chrono::Utc.ymd(year, month, day),
         }
     }
 
@@ -127,7 +129,7 @@ impl Date {
 
         Self::new(
             today_js.get_utc_full_year() as i32,
-            today_js.get_utc_month() as u32 + 1,  // JS using 0-based month indexing. Fix it.
+            today_js.get_utc_month() as u32 + 1, // JS using 0-based month indexing. Fix it.
             today_js.get_utc_date() as u32,
         )
     }
@@ -140,20 +142,20 @@ impl Date {
             wrapped: chrono::Utc
                 .datetime_from_str(padded, "%Y-%m-%dT%H%M%S")
                 .expect(&format!("Can't format date: {}", date))
-                .date()
+                .date(),
         }
     }
 
     // todo operator overload with other being diff type?
     pub fn add(&self, dur: chrono::Duration) -> Self {
         Self {
-            wrapped: self.wrapped.clone() + dur
+            wrapped: self.wrapped.clone() + dur,
         }
     }
 
     pub fn sub(&self, dur: chrono::Duration) -> Self {
         Self {
-            wrapped: self.wrapped.clone() - dur
+            wrapped: self.wrapped.clone() - dur,
         }
     }
 

--- a/examples/server_interaction_detailed/src/interfaces.rs
+++ b/examples/server_interaction_detailed/src/interfaces.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use chrono::offset::{TimeZone, Utc};
-use chrono::Date;
+//use chrono::offset::{TimeZone, Utc};
+//use chrono::Date;
 
 // u32 generally refers to an id. i8 refers to a choice.
 

--- a/examples/server_interaction_detailed/src/lib.rs
+++ b/examples/server_interaction_detailed/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod datetime;
-pub mod util;
 pub mod interfaces;
+pub mod util;

--- a/examples/server_interaction_detailed/src/util.rs
+++ b/examples/server_interaction_detailed/src/util.rs
@@ -15,7 +15,6 @@ pub const MX_NE_WX: i8 = 1;
 pub const MX_NE_OPS: i8 = 2;
 pub const MX_NE_MX: i8 = 3;
 
-
 pub fn short_name(person: &Person) -> String {
     format! {"{}, {}", person.last_name, person.first_name}
     // todo first initial.

--- a/examples/server_interaction_detailed/src/util.rs
+++ b/examples/server_interaction_detailed/src/util.rs
@@ -1,8 +1,9 @@
-use std::cmp::Ordering;
-use std::fmt;
-use std::ops::{Add, Sub};
+//use std::cmp::Ordering;
+//use std::fmt;
+//use std::ops::{Add, Sub};
 
 use crate::interfaces::{Line, Person};
+use std::borrow::ToOwned;
 //use chrono::Datelike;
 
 // We use these integers instead of enums for compatibility with the database and serialization.
@@ -20,23 +21,23 @@ pub fn short_name(person: &Person) -> String {
     // todo first initial.
 }
 
-fn includes_line(lines: &Vec<Line>, line: &Line) -> bool {
+fn includes_line(lines: &[Line], line: &Line) -> bool {
     // Helper function that determines if a line's within another's set.
     for l in lines {
         if l.id == line.id {
             return true;
         }
     }
-    return false;
+    false
 }
 
-pub fn formation_lines(selected_line: &Line, lines: &Vec<Line>) -> Vec<Line> {
-    // todo sloppy clone
-    let mut sorted_lines = lines.clone();
+pub fn formation_lines(selected_line: &Line, lines: &[Line]) -> Vec<Line> {
+    // todo sloppy clone (in to_owned)
+    let mut sorted_lines = lines.to_owned();
     sorted_lines.sort_by(|a, b| a.number.cmp(&b.number));
 
     let mut current_form = Vec::new();
-    for line in sorted_lines.into_iter() {
+    for line in sorted_lines {
         if line.flight_lead {
             // We've found the start of a new form. Was the last one our result?
             if includes_line(&current_form, selected_line) {
@@ -52,7 +53,7 @@ pub fn formation_lines(selected_line: &Line, lines: &Vec<Line>) -> Vec<Line> {
     if includes_line(&current_form, selected_line) {
         return current_form;
     }
-    return current_form;
+    current_form
 }
 
 pub fn is_aircrew(person: &Person) -> bool {

--- a/examples/todomvc/Makefile.toml
+++ b/examples/todomvc/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -1,5 +1,4 @@
-//! Modelled after the todomvc project's Typescript-React example:
-//! https://github.com/tastejs/todomvc/tree/gh-pages/examples/typescript-react
+//! Modelled after the todomvc project's [Typescript-React example](https://github.com/tastejs/todomvc/tree/gh-pages/examples/typescript-react)
 
 #[macro_use]
 extern crate seed;
@@ -36,7 +35,7 @@ struct Todo {
 }
 
 impl Todo {
-    fn visible(&self, visible: &Visible) -> bool {
+    fn visible(&self, visible: Visible) -> bool {
         match visible {
             Visible::All => true,
             Visible::Active => !self.completed,
@@ -54,14 +53,14 @@ struct Model {
 }
 
 impl Model {
-    fn completed_count(&self) -> i32 {
+    fn completed_count(&self) -> usize {
         let completed: Vec<&Todo> = self.todos.iter().filter(|i| i.completed).collect();
-        completed.len() as i32
+        completed.len()
     }
 
-    fn active_count(&self) -> i32 {
+    fn active_count(&self) -> usize {
         // By process of elimination; active means not completed.
-        self.todos.len() as i32 - self.completed_count()
+        self.todos.len() - self.completed_count()
     }
 
     fn sync_storage(&self) {
@@ -295,11 +294,18 @@ fn view(model: &Model) -> Vec<El<Msg>> {
         .clone()
         .into_iter()
         .enumerate()
-        .filter(|(_posit, todo)| todo.visible(&model.visible))
-        .map(|(posit, todo)| todo_item(&todo, posit, &model.edit_text))
+        .filter_map(|(posit, todo)| {
+            if todo.visible(model.visible) {
+                Some(todo_item(&todo, posit, &model.edit_text))
+            } else {
+                None
+            }
+        })
         .collect();
 
-    let main = if !model.todos.is_empty() {
+    let main = if model.todos.is_empty() {
+        seed::empty()
+    } else {
         section![
             class!["main"],
             input![
@@ -310,8 +316,6 @@ fn view(model: &Model) -> Vec<El<Msg>> {
             label![attrs! {At::For => "toggle-all"}, "Mark all as complete"],
             ul![class!["todo-list"], todo_els]
         ]
-    } else {
-        seed::empty()
     };
 
     vec![
@@ -331,7 +335,7 @@ fn view(model: &Model) -> Vec<El<Msg>> {
         ],
         main,
         if model.active_count() > 0 || model.completed_count() > 0 {
-            footer(&model)
+            footer(model)
         } else {
             seed::empty()
         },

--- a/examples/update_from_js/Makefile.toml
+++ b/examples/update_from_js/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/websocket/Makefile.toml
+++ b/examples/websocket/Makefile.toml
@@ -70,3 +70,8 @@ description = "Run websocket server on port 9000 in release mode"
 args = ["run", "--bin", "server", "--features", "server", "--release"]
 dependencies = ["build_server_release"]
 
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"
+

--- a/examples/websocket/src/json.rs
+++ b/examples/websocket/src/json.rs
@@ -1,12 +1,12 @@
 /// Message from the server to the client.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct ServerMsg {
+pub struct ServerMessage {
     pub id: usize,
     pub text: String,
 }
 
 /// Message from the client to the server.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct ClientMsg {
+pub struct ClientMessage {
     pub text: String,
 }

--- a/examples/websocket/src/server.rs
+++ b/examples/websocket/src/server.rs
@@ -27,14 +27,15 @@ impl Handler for Server {
     fn on_message(&mut self, msg: Message) -> Result<()> {
         let client_id: usize = self.out.token().into();
 
-        let client_msg: json::ClientMsg = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+        let client_msg: json::ClientMessage =
+            serde_json::from_str(&msg.into_text().unwrap()).unwrap();
 
         println!(
             "Server received text: '{}'\nfrom client '{}'\n",
             client_msg.text, client_id
         );
 
-        let server_msg: Message = serde_json::to_string(&json::ServerMsg {
+        let server_msg: Message = serde_json::to_string(&json::ServerMessage {
             id: client_id,
             text: client_msg.text,
         })

--- a/examples/window_events/Makefile.toml
+++ b/examples/window_events/Makefile.toml
@@ -15,3 +15,8 @@ alias = "default_start"
 
 [tasks.start_release]
 alias = "default_start_release"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/window_events/src/lib.rs
+++ b/examples/window_events/src/lib.rs
@@ -45,7 +45,7 @@ fn misc_demo() -> El<Msg> {
     custom_el.set_text(""); // Demo of set_text.
 
     let mut attributes = attrs! {};
-    attributes.add_multiple(At::Class, vec!["a-modicum-of", "hardly-any"]);
+    attributes.add_multiple(At::Class, &["a-modicum-of", "hardly-any"]);
 
     custom![
         Tag::Custom("superdiv".into()),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,22 @@
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
+
+newline_style = "Unix"
+use_field_init_shorthand = true
+use_try_shorthand = true
+
+
+# nightly
+
+#normalize_doc_attributes = true
+#reorder_impl_items = true
+#normalize_comments = true
+#wrap_comments = true
+#format_strings = true
+#match_block_trailing_comma = true
+#trailing_comma = "Always"
+#merge_imports = true
+#error_on_line_overflow = true
+#error_on_unformatted = true
+#report_todo = "Always"
+#report_fixme = "Always"
+#version = "Two"

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -3,10 +3,10 @@
 
 use super::{util, websys_bridge};
 use core::convert::AsRef;
+use indexmap::IndexMap;
 use pulldown_cmark;
 use serde::de::DeserializeOwned;
 use std::fmt;
-use indexmap::IndexMap;
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! See readme for details.
 
 //#![deny(missing_docs)]
+#![allow(clippy::use_self, clippy::single_match_else)]
 
 pub use crate::{
     fetch::{Method, Request},
@@ -39,11 +40,11 @@ pub fn empty<Ms>() -> dom_types::El<Ms> {
     el
 }
 
-/// A high-level wrapper for web_sys::window.set_interval_with_callback_and_timeout_and_arguments_0:
+/// A high-level wrapper for `web_sys::window.set_interval_with_callback_and_timeout_and_arguments_0`:
 ///
 /// # References
 /// * [WASM bindgen closures](https://rustwasm.github.io/wasm-bindgen/examples/closures.html)
-/// * [web_sys Window](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Window.html)
+/// * [`web_sys` Window](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Window.html)
 /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval)
 pub fn set_interval(handler: Box<Fn()>, timeout: i32) {
     let callback = Closure::wrap(handler as Box<dyn Fn()>);
@@ -56,7 +57,7 @@ pub fn set_interval(handler: Box<Fn()>, timeout: i32) {
     callback.forget();
 }
 
-/// See [set_interval](fn.set_interval.html)
+/// See [`set_interval`](fn.set_interval.html)
 ///
 ///
 /// # References
@@ -72,10 +73,10 @@ pub fn set_timeout(handler: Box<Fn()>, timeout: i32) {
     callback.forget();
 }
 
-/// Introduce El and Tag into the global namespace for convenience (El will be repeated
-/// often in the output type of components), and UpdateEl, which is required
-/// for element-creation macros, input event constructors, and the History struct.
-/// Expose the wasm_bindgen prelude, and lifecycle hooks.
+/// Introduce `El` and `Tag` into the global namespace for convenience (`El` will be repeated
+/// often in the output type of components), and `UpdateEl`, which is required
+/// for element-creation macros, input event constructors, and the `History` struct.
+/// Expose the `wasm_bindgen` prelude, and lifecycle hooks.
 pub mod prelude {
     pub use crate::{
         dom_types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,10 @@ pub mod prelude {
             Optimize::Key, Tag, UpdateEl,
         },
         shortcuts::*, // appears not to work.
-        vdom::{Orders, call_update},
-        util::{request_animation_frame, RequestAnimationFrameHandle, RequestAnimationFrameTime}
+        util::{request_animation_frame, RequestAnimationFrameHandle, RequestAnimationFrameTime},
+        vdom::{call_update, Orders},
     };
-    pub use indexmap::IndexMap;  // for attrs and style to work.
+    pub use indexmap::IndexMap; // for attrs and style to work.
 
     pub use wasm_bindgen::prelude::*;
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 
-/// Repeated here from seed::util, to make this module standalone.  Once we have a Gloo module
+/// Repeated here from `seed::util`, to make this module standalone.  Once we have a Gloo module
 /// that handles this, use it.
 mod util {
     /// Convenience function to avoid repeating expect logic.
@@ -11,12 +11,12 @@ mod util {
         web_sys::window().expect("Can't find the global Window")
     }
 
-    /// Convenience function to access the web_sys DOM document.
+    /// Convenience function to access the `web_sys` DOM document.
     pub fn document() -> web_sys::Document {
         window().document().expect("Can't find document")
     }
 
-    /// Convenience function to access web_sys history
+    /// Convenience function to access `web_sys` history
     pub fn history() -> web_sys::History {
         window().history().expect("Can't find history")
     }
@@ -74,7 +74,7 @@ impl Url {
 impl From<String> for Url {
     // todo: Include hash and search.
     fn from(s: String) -> Self {
-        let mut path: Vec<String> = s.split('/').map(|s2| s2.to_string()).collect();
+        let mut path: Vec<String> = s.split('/').map(ToString::to_string).collect();
         path.remove(0); // Remove a leading empty string.
         Self {
             path,
@@ -108,16 +108,19 @@ fn get_path() -> String {
 }
 
 fn get_hash() -> String {
-    let hash = util::window().location().hash().expect("Can't find hash");
-    hash.to_string().replace("#", "")
+    util::window()
+        .location()
+        .hash()
+        .expect("Can't find hash")
+        .replace("#", "")
 }
 
 fn get_search() -> String {
-    let search = util::window()
+    util::window()
         .location()
         .search()
-        .expect("Can't find search");
-    search.to_string().replace("?", "")
+        .expect("Can't find search")
+        .replace("?", "")
 }
 
 /// For setting up landing page routing. Unlike normal routing, we can't rely
@@ -128,7 +131,7 @@ where
 {
     let raw_path = get_path();
     let path_ref: Vec<&str> = raw_path.split('/').collect();
-    let path: Vec<String> = path_ref.into_iter().map(|p| p.to_string()).collect();
+    let path: Vec<String> = path_ref.into_iter().map(ToString::to_string).collect();
 
     let raw_hash = get_hash();
     let hash = match raw_hash.len() {
@@ -173,7 +176,7 @@ fn clean_url(mut url: Url) -> Url {
     url
 }
 
-/// Add a new route using history's push_state method.
+/// Add a new route using history's `push_state` method.
 ///
 /// # Refenences
 /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/History_API)

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -1,7 +1,7 @@
 //! This file exports helper macros for element creation, populated by a higher-level macro,
 //! and macros for creating the parts of elements. (attrs, style, events)
 
-/// Copied from [https://github.com/rust-lang/rust/issues/35853][https://github.com/rust-lang/rust/issues/35853]
+/// Copied from [https://github.com/rust-lang/rust/issues/35853](https://github.com/rust-lang/rust/issues/35853)
 macro_rules! with_dollar_sign {
     ($($body:tt)*) => {
         macro_rules! __with_dollar_sign { $($body)* }
@@ -11,7 +11,7 @@ macro_rules! with_dollar_sign {
 
 /// Create macros exposed to the package that allow shortcuts for Dom elements.
 /// In the matching pattern below, we match the name we want to use with the name under
-/// the seed::dom_types::Tag enum. Eg the div! macro uses seed::dom_types::Tag::Div.
+/// the `seed::dom_types::Tag` enum. Eg the div! macro uses `seed::dom_types::Tag::Div`.
 macro_rules! element {
     // Create shortcut macros for any element; populate these functions in this module.
     ($($Tag:ident => $Tag_camel:ident);+) => {
@@ -191,7 +191,7 @@ macro_rules! class {
             $(
                 classes.push($class);
             )*
-            result.add_multiple("class".into(), classes);
+            result.add_multiple(At::Class, &classes);
             result
         }
      };
@@ -324,7 +324,7 @@ macro_rules! error {
      };
 }
 
-/// A IndexMap literal, where the keys and values must implement ToString.
+/// A IndexMap literal, where the keys and values must implement `ToString`.
 #[macro_export]
 macro_rules! hashmap_string {
     { $($key:expr => $value:expr),* $(,)* } => {

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -58,7 +58,7 @@ macro_rules! element_svg {
    }
 }
 
-/// El must be exposed in the module where this is called for these to work.
+// El must be exposed in the module where this is called for these to work.
 element! {
     address => Address; article => Article; aside => Aside; footer => Footer;
     header => Header; h1 => H1;

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -324,12 +324,12 @@ macro_rules! error {
      };
 }
 
-/// A IndexMap literal, where the keys and values must implement `ToString`.
+/// A key-value pairs, where the keys and values must implement `ToString`.
 #[macro_export]
-macro_rules! hashmap_string {
+macro_rules! key_value_pairs {
     { $($key:expr => $value:expr),* $(,)* } => {
         {
-            let mut result = std::collections::HashMap::new();
+            let mut result = IndexMap::new();
             $(
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,13 +8,13 @@
 extern crate serde;
 extern crate serde_json;
 
+#[allow(clippy::module_name_repetitions)]
 pub fn get_storage() -> Option<web_sys::Storage> {
     let window = web_sys::window().unwrap();
 
     match window.local_storage() {
         Ok(Some(local_storage)) => Some(local_storage),
-        Err(_) => None,
-        Ok(None) => None,
+        Err(_) | Ok(None) => None,
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-//! Provide a wrapper for commonly-used, but verbose web_sys features.
+//! Provide a wrapper for commonly-used, but verbose `web_sys` features.
 //! This module is decoupled / independent.
 
 use crate::dom_types;
@@ -27,19 +27,19 @@ pub fn window() -> web_sys::Window {
     web_sys::window().expect("Can't find the global Window")
 }
 
-/// Convenience function to access the web_sys DOM document.
+/// Convenience function to access the `web_sys` DOM document.
 pub fn document() -> web_sys::Document {
     window()
         .document()
         .expect("Can't find the window's document")
 }
 
-/// Convenience function to access the web_sys DOM body.
+/// Convenience function to access the `web_sys` DOM body.
 pub fn body() -> web_sys::HtmlElement {
     document().body().expect("Can't find the document's body")
 }
 
-/// Convenience function to access the web_sys history.
+/// Convenience function to access the `web_sys` history.
 pub fn history() -> web_sys::History {
     window().history().expect("Can't find history")
 }
@@ -60,7 +60,7 @@ pub fn request_animation_frame(
 }
 
 /// Simplify getting the value of input elements; required due to the need to cast
-/// from general nodes/elements to HTML_Elements.
+/// from general nodes/elements to `HTML_Elements`.
 pub fn get_value(target: &web_sys::EventTarget) -> String {
     if let Some(input) = target.dyn_ref::<web_sys::HtmlInputElement>() {
         return input.value();
@@ -74,7 +74,7 @@ pub fn get_value(target: &web_sys::EventTarget) -> String {
     "".into()
 }
 
-/// Similar to get_value.
+/// Similar to `get_value`.
 pub fn set_value(target: &web_sys::EventTarget, value: &str) {
     if let Some(input) = target.dyn_ref::<web_sys::HtmlInputElement>() {
         input.set_value(value);

--- a/src/util.rs
+++ b/src/util.rs
@@ -46,12 +46,11 @@ pub fn history() -> web_sys::History {
 
 /// Request the animation frame.
 pub fn request_animation_frame(
-    f: Closure<FnMut(RequestAnimationFrameTime)>
+    f: Closure<FnMut(RequestAnimationFrameTime)>,
 ) -> RequestAnimationFrameHandle {
-    let request_id =
-        window()
-            .request_animation_frame(f.as_ref().unchecked_ref())
-            .expect("Problem requesting animation frame");
+    let request_id = window()
+        .request_animation_frame(f.as_ref().unchecked_ref())
+        .expect("Problem requesting animation frame");
 
     RequestAnimationFrameHandle {
         request_id,
@@ -111,8 +110,8 @@ pub fn error<D: fmt::Debug>(text: D) {
 /// It requires Msg to be (De)serializable
 /// and to register `trigger_update_handler` in `window_events`.
 pub fn update<Ms>(msg: Ms)
-    where
-        Ms: Clone + 'static + serde::Serialize,
+where
+    Ms: Clone + 'static + serde::Serialize,
 {
     let msg_as_js_value = wasm_bindgen::JsValue::from_serde(&msg)
         .expect("Error: TriggerUpdate - can't serialize given msg!");
@@ -124,7 +123,7 @@ pub fn update<Ms>(msg: Ms)
         dom_types::UPDATE_TRIGGER_EVENT_ID,
         &custom_event_config,
     )
-        .expect("Error: TriggerUpdate - create event failed!");
+    .expect("Error: TriggerUpdate - create event failed!");
 
     window()
         .dispatch_event(&event)

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -36,7 +36,7 @@ pub fn call_update<Ms, Mdl>(update: UpdateFn<Ms, Mdl>, msg: Ms, model: &mut Mdl)
 
 pub enum Effect<Ms> {
     Msg(Ms),
-    Cmd(Box<dyn Future<Item=Ms, Error=Ms> + 'static>),
+    Cmd(Box<dyn Future<Item = Ms, Error = Ms> + 'static>),
 }
 
 impl<Ms> From<Ms> for Effect<Ms> {
@@ -130,8 +130,8 @@ impl<Ms: 'static> Orders<Ms> {
     ///orders.perform_cmd(write_emoticon_after_delay());
     /// ```
     pub fn perform_cmd<C>(&mut self, cmd: C) -> &mut Self
-        where
-            C: Future<Item=Ms, Error=Ms> + 'static,
+    where
+        C: Future<Item = Ms, Error = Ms> + 'static,
     {
         self.effects.push_back(Effect::Cmd(Box::new(cmd)));
         self
@@ -185,10 +185,10 @@ pub struct AppData<Ms: 'static, Mdl> {
 }
 
 pub struct AppCfg<Ms, Mdl, ElC>
-    where
-        Ms: 'static,
-        Mdl: 'static,
-        ElC: ElContainer<Ms>,
+where
+    Ms: 'static,
+    Mdl: 'static,
+    ElC: ElContainer<Ms>,
 {
     document: web_sys::Document,
     mount_point: web_sys::Element,
@@ -198,10 +198,10 @@ pub struct AppCfg<Ms, Mdl, ElC>
 }
 
 pub struct App<Ms, Mdl, ElC>
-    where
-        Ms: 'static,
-        Mdl: 'static,
-        ElC: ElContainer<Ms>,
+where
+    Ms: 'static,
+    Mdl: 'static,
+    ElC: ElContainer<Ms>,
 {
     /// Stateless app configuration
     pub cfg: Rc<AppCfg<Ms, Mdl, ElC>>,
@@ -454,12 +454,12 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
                 self.cancel_scheduled_render();
                 self.rerender_vdom();
             }
-            ShouldRender::Skip => ()
+            ShouldRender::Skip => (),
         };
         orders.effects
     }
 
-    fn process_queue_cmd(&self, cmd: Box<dyn Future<Item=Ms, Error=Ms>>) {
+    fn process_queue_cmd(&self, cmd: Box<dyn Future<Item = Ms, Error = Ms>>) {
         let lazy_schedule_cmd = enclose!((self => s) move |_| {
             // schedule future (cmd) to be executed
             spawn_local(cmd.then(move |res| {
@@ -474,14 +474,14 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
     }
 
     fn schedule_render(&self) {
-        let mut scheduled_render_handle =
-            self.data.scheduled_render_handle.borrow_mut();
+        let mut scheduled_render_handle = self.data.scheduled_render_handle.borrow_mut();
 
         if scheduled_render_handle.is_none() {
             let cb = Closure::wrap(Box::new(enclose!((self => s) move |_| {
                 s.rerender_vdom();
                 s.data.scheduled_render_handle.borrow_mut().take();
-            })) as Box<FnMut(util::RequestAnimationFrameTime)>);
+            }))
+                as Box<FnMut(util::RequestAnimationFrameTime)>);
 
             *scheduled_render_handle = Some(util::request_animation_frame(cb));
         }
@@ -562,8 +562,8 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
     }
 
     pub fn add_message_listener<F>(&self, listener: F)
-        where
-            F: Fn(&Ms) + 'static,
+    where
+        F: Fn(&Ms) + 'static,
     {
         self.data
             .msg_listeners
@@ -597,8 +597,8 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
 /// doesn't trigger a re-render, or if something else modifies them using a side effect.
 /// Handle controlled inputs: Ie force sync with the model.
 fn setup_input_listener<Ms>(el: &mut El<Ms>)
-    where
-        Ms: 'static,
+where
+    Ms: 'static,
 {
     if el.tag == dom_types::Tag::Input
         || el.tag == dom_types::Tag::Select
@@ -623,8 +623,8 @@ fn setup_input_listener<Ms>(el: &mut El<Ms>)
 
 // Create the web_sys element; add it to the working tree; store it in its corresponding vdom El.
 fn setup_websys_el<Ms>(document: &Document, el: &mut El<Ms>)
-    where
-        Ms: 'static,
+where
+    Ms: 'static,
 {
     if el.el_ws.is_none() {
         el.el_ws = Some(websys_bridge::make_websys_el(el, document));
@@ -633,16 +633,16 @@ fn setup_websys_el<Ms>(document: &Document, el: &mut El<Ms>)
 
 /// Recursively sets up input listeners
 fn setup_input_listeners<Ms>(el_vdom: &mut El<Ms>)
-    where
-        Ms: 'static,
+where
+    Ms: 'static,
 {
     el_vdom.walk_tree_mut(setup_input_listener);
 }
 
 /// Recursively sets up `web_sys` elements
 fn setup_websys_el_and_children<Ms>(document: &Document, el: &mut El<Ms>)
-    where
-        Ms: 'static,
+where
+    Ms: 'static,
 {
     el.walk_tree_mut(|el| setup_websys_el(document, el));
 }
@@ -750,7 +750,7 @@ pub(crate) fn patch<'a, Ms, Mdl, ElC: ElContainer<Ms>>(
             }
 
             return None;
-            // If new and old are empty, we don't need to do anything.
+        // If new and old are empty, we don't need to do anything.
         } else if new.empty && old.empty {
             return None;
         }
@@ -1019,11 +1019,11 @@ pub mod tests {
         new_vdom
     }
 
-    fn iter_nodelist(list: web_sys::NodeList) -> impl Iterator<Item=Node> {
+    fn iter_nodelist(list: web_sys::NodeList) -> impl Iterator<Item = Node> {
         (0..list.length()).map(move |i| list.item(i).unwrap())
     }
 
-    fn iter_child_nodes(node: &Node) -> impl Iterator<Item=Node> {
+    fn iter_child_nodes(node: &Node) -> impl Iterator<Item = Node> {
         iter_nodelist(node.child_nodes())
     }
 
@@ -1492,7 +1492,7 @@ pub mod tests {
 
     /// Tests an update() function that repeatedly sends messages or performs commands.
     #[wasm_bindgen_test(async)]
-    fn update_promises() -> impl Future<Item=(), Error=JsValue> {
+    fn update_promises() -> impl Future<Item = (), Error = JsValue> {
         // ARRANGE
 
         // when we call `test_value_sender.send(..)`, future `test_value_receiver` will be marked as resolved
@@ -1560,9 +1560,9 @@ pub mod tests {
             update,
             |_| seed::empty(),
         )
-            .mount(seed::body())
-            .finish()
-            .run();
+        .mount(seed::body())
+        .finish()
+        .run();
 
         // ACT
         app.update(Msg::Start);

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -29,7 +29,7 @@ use web_sys::{Document, Element, Event, EventTarget, Window};
 ///}
 /// ```
 pub fn call_update<Ms, Mdl>(update: UpdateFn<Ms, Mdl>, msg: Ms, model: &mut Mdl) -> Orders<Ms> {
-    let mut orders: Orders<Ms> = Default::default();
+    let mut orders = Orders::<Ms>::default();
     (update)(msg, model, &mut orders);
     orders
 }
@@ -55,7 +55,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Effect<Ms> {
     }
 }
 
-/// Determines if an update should cause the VDom to rerender or not.
+/// Determines if an update should cause the `VDom` to rerender or not.
 pub enum ShouldRender {
     Render,
     ForceRenderNow,
@@ -582,7 +582,7 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
             .clone()
             .expect("Can't find main vdom el in find");
 
-        find_el(ref_, &top_el)
+        find_el(ref_, top_el)
     }
 
     fn mailbox(&self) -> Mailbox<Ms> {
@@ -592,7 +592,7 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
     }
 }
 
-/// Set up controlled components: Input, Select, and TextArea elements must stay in sync with the
+/// Set up controlled components: Input, Select, and `TextArea` elements must stay in sync with the
 /// model; don't let them get out of sync from typing or other events, which can occur if a change
 /// doesn't trigger a re-render, or if something else modifies them using a side effect.
 /// Handle controlled inputs: Ie force sync with the model.
@@ -639,7 +639,7 @@ fn setup_input_listeners<Ms>(el_vdom: &mut El<Ms>)
     el_vdom.walk_tree_mut(setup_input_listener);
 }
 
-/// Recursively sets up web_sys elements
+/// Recursively sets up `web_sys` elements
 fn setup_websys_el_and_children<Ms>(document: &Document, el: &mut El<Ms>)
     where
         Ms: 'static,
@@ -649,7 +649,7 @@ fn setup_websys_el_and_children<Ms>(document: &Document, el: &mut El<Ms>)
 
 impl<Ms, Mdl, ElC: ElContainer<Ms>> Clone for App<Ms, Mdl, ElC> {
     fn clone(&self) -> Self {
-        App {
+        Self {
             cfg: Rc::clone(&self.cfg),
             data: Rc::clone(&self.data),
         }
@@ -663,7 +663,7 @@ fn attach_listeners<Ms>(el: &mut dom_types::El<Ms>, mailbox: &Mailbox<Ms>) {
             for listener in &mut el.listeners {
                 // todo ideally we unify attach as one method
                 if listener.control_val.is_some() || listener.control_checked.is_some() {
-                    listener.attach_control(&el_ws);
+                    listener.attach_control(el_ws);
                 } else {
                     listener.attach(el_ws, mailbox.clone());
                 }
@@ -811,7 +811,7 @@ pub(crate) fn patch<'a, Ms, Mdl, ElC: ElContainer<Ms>>(
                 //                }
             }
 
-            attach_listeners(new, &mailbox);
+            attach_listeners(new, mailbox);
             // We've re-rendered this child and all children; we're done with this recursion.
             return new.el_ws.as_ref();
         } else {
@@ -874,7 +874,7 @@ pub(crate) fn patch<'a, Ms, Mdl, ElC: ElContainer<Ms>>(
                 Some(node) => node.next_sibling(),
                 None => old_el_ws.first_child(),
             },
-            &mailbox,
+            mailbox,
             app,
         ) {
             last_visited_node = Some(new_el_ws.clone());
@@ -889,7 +889,7 @@ pub(crate) fn patch<'a, Ms, Mdl, ElC: ElContainer<Ms>>(
         // We ran out of old children to patch; create new ones.
         setup_websys_el_and_children(document, child_new);
         websys_bridge::attach_el_and_children(child_new, &old_el_ws, app);
-        attach_listeners(child_new, &mailbox);
+        attach_listeners(child_new, mailbox);
     }
 
     // Now purge any existing no-longer-needed children; they're not part of the new vdom.
@@ -929,7 +929,7 @@ pub trait _Listener<Ms>: Sized {
 }
 
 /// WIP towards a modular VDOM
-/// Assumes dependency on web_sys.
+/// Assumes dependency on `web_sys`.
 // TODO:: Do we need <Ms> ?
 pub trait _DomEl<Ms>: Sized + PartialEq + DomElLifecycle {
     // TODO: tostring

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -1,4 +1,4 @@
-//! This file contains interactions with web_sys.
+//! This file contains interactions with `web_sys`.
 use wasm_bindgen::JsCast;
 
 use crate::dom_types;
@@ -112,17 +112,17 @@ fn set_style(el_ws: &web_sys::Node, style: &dom_types::Style) {
         .expect("Problem setting style");
 }
 
-/// Create and return a web_sys Element from our virtual-dom El. The web_sys
+/// Create and return a `web_sys` Element from our virtual-dom `El`. The `web_sys`
 /// Element is a close analog to JS/DOM elements.
 ///
 /// # References
-/// * [web_sys Element](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Element.html)
+/// * [`web_sys` Element](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Element.html)
 /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element\)
-/// * See also: [web_sys Node](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Node.html)
+/// * See also: [`web_sys` Node](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Node.html)
 pub fn make_websys_el<Ms>(el_vdom: &mut El<Ms>, document: &web_sys::Document) -> web_sys::Node {
     // A simple text node.
     if let Some(text) = &el_vdom.text {
-        return document.create_text_node(&text).into();
+        return document.create_text_node(text).into();
     }
 
     // Create the DOM-analog element; it won't render until attached to something.
@@ -158,7 +158,7 @@ pub fn make_websys_el<Ms>(el_vdom: &mut El<Ms>, document: &web_sys::Document) ->
     el_ws.into()
 }
 
-/// Similar to attach_el_and_children, but assumes we've already attached the parent.
+/// Similar to `attach_el_and_children`, but assumes we've already attached the parent.
 pub fn attach_children<Ms, Mdl, ElC: ElContainer<Ms>>(
     el_vdom: &mut El<Ms>,
     app: &App<Ms, Mdl, ElC>,
@@ -243,15 +243,15 @@ pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_
                 Some(old_val) => {
                     // The value's different
                     if old_val != new_val {
-                        set_attr_shim(&old_el_ws, key, new_val);
+                        set_attr_shim(old_el_ws, key, new_val);
                     }
                 }
-                None => set_attr_shim(&old_el_ws, key, new_val),
+                None => set_attr_shim(old_el_ws, key, new_val),
             }
             // We handle value in the vdom using attributes, but the DOM needs
             // to use set_value.
             if key == &dom_types::At::Value {
-                crate::util::set_value(old_el_ws, &new_val);
+                crate::util::set_value(old_el_ws, new_val);
             }
         }
         // Remove attributes that aren't in the new vdom.
@@ -277,7 +277,7 @@ pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_
     // Patch style.
     if old.style != new.style {
         // We can't patch each part of style; rewrite the whole attribute.
-        set_style(&old_el_ws, &new.style)
+        set_style(old_el_ws, &new.style)
     }
 
     // Patch text
@@ -298,28 +298,28 @@ pub fn to_input(target: &web_sys::EventTarget) -> &web_sys::HtmlInputElement {
         .expect("Unable to cast as an input element")
 }
 
-/// See [to_input](fn.to_input.html)
+/// See [`to_input`](fn.to_input.html)
 pub fn to_textarea(target: &web_sys::EventTarget) -> &web_sys::HtmlTextAreaElement {
     target
         .dyn_ref::<web_sys::HtmlTextAreaElement>()
         .expect("Unable to cast as a textarea element")
 }
 
-/// See [to_input](fn.to_input.html)
+/// See [`to_input`](fn.to_input.html)
 pub fn to_select(target: &web_sys::EventTarget) -> &web_sys::HtmlSelectElement {
     target
         .dyn_ref::<web_sys::HtmlSelectElement>()
         .expect("Unable to cast as a select element")
 }
 
-/// See [to_input](fn.to_input.html)
+/// See [`to_input`](fn.to_input.html)
 pub fn to_html_el(target: &web_sys::EventTarget) -> &web_sys::HtmlElement {
     target
         .dyn_ref::<web_sys::HtmlElement>()
         .expect("Unable to cast as an HTML element")
 }
 
-/// Convert a web_sys::Event to a web_sys::KeyboardEvent. Useful for extracting
+/// Convert a `web_sys::Event` to a `web_sys::KeyboardEvent`. Useful for extracting
 /// info like which key has been pressed, which is not available with normal Events.
 pub fn to_kbevent(event: &web_sys::Event) -> &web_sys::KeyboardEvent {
     event
@@ -327,14 +327,14 @@ pub fn to_kbevent(event: &web_sys::Event) -> &web_sys::KeyboardEvent {
         .expect("Unable to cast as a keyboard event")
 }
 
-/// See to_kbevent
+/// See `to_kbevent`
 pub fn to_mouse_event(event: &web_sys::Event) -> &web_sys::MouseEvent {
     event
         .dyn_ref::<web_sys::MouseEvent>()
         .expect("Unable to cast as a mouse event")
 }
 
-/// Create a vdom node from a web_sys::Element. Used in creating elements from html
+/// Create a vdom node from a `web_sys::Element`. Used in creating elements from html
 /// and markdown strings. Includes children, recursively added.
 pub fn el_from_ws<Ms>(node: &web_sys::Node) -> Option<El<Ms>> {
     match node.node_type() {


### PR DESCRIPTION
#125 
Changes:
- New tasks, the most useful are:
  - `cargo make fmt_all`
  - `cargo make fmt_all_check`
  - `cargo make clippy_one [example]`
  - `cargo make clippy_all`
- Added `rustfmt.toml` - I've added some rules which I think are useful or I saw them in some other Rust repositories. The most of them waits for stabilization.
- Updated `.travis.yml` - it uses `fmt_all_check` and `clippy_all`.
- Many smaller changes to satisfy pedantic clippy. There are some explicit `allow`s when I thought that clippy was wrong or tried to make code less readable.
- I've renamed macro `hashmap_string` to `key_value_pairs` (terminology from https://hexdocs.pm/elixir/Map.html). And changed `HashMap` to `IndexMap` in its implementation (#124 ).
- `fetch.rs` - Added variant `Unknown` into enum `StatusCategory` => `Status::from(..)` can't fail now.

---

- I didn't squash commits so you can see my steps while I was doing refactor. I'll squash them if you want.
- I haven't add pre-commit/push hook - I'll add it if we find out that CI often fails and it's annoying.
- I recommend you look at all changes - I tried to not change business logic, but there can be something that I overlooked and there are some interesting changes made on Clippy's advice. If something doesn't make sense / isn't readable, I'll try to write my reasoning about it.
- Look at the list of default [cargo make commands](https://sagiegurari.github.io/cargo-make/#usage-predefined-flows-cargo) => there are some interesting ones which we can integrate in the future (e.g. `audit`, `verify-project`, etc.) ; (they are implemented [here](https://github.com/sagiegurari/cargo-make/blob/master/src/lib/Makefile.stable.toml)).

