### PR TITLE
127-css-units

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ fn view(model: &Model) -> El<Msg> {
             style!{
                 // Example of conditional logic in a style.
                 "color" => if model.count > 4 {"purple"} else {"gray"};
-                // When passing numerical values to style!, "px" is implied.
-                "border" => "2px solid #004422"; "padding" => 20
+                "border" => "2px solid #004422"; 
+                "padding" => unit!(20, px);
             },
             // We can use normal Rust code and comments in the view.
             h3![ format!("{} {}{} so far", model.count, model.what_we_count, plural) ],
@@ -170,7 +170,7 @@ fn view(model: &Model) -> El<Msg> {
             button![ simple_ev(Ev::Click, Msg::Decrement), "-" ],
 
             // Optionally-displaying an element
-            if model.count >= 10 { h2![ style!{"padding" => 50}, "Nice!" ] } else { empty![] }
+            if model.count >= 10 { h2![ style!{"padding" => px(50)}, "Nice!" ] } else { empty![] }
         ],
         success_level(model.count),  // Incorporating a separate component
 

--- a/examples/animation_frame/src/lib.rs
+++ b/examples/animation_frame/src/lib.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 extern crate seed;
-#[macro_use]
-extern crate serde_derive;
 use rand::prelude::*;
 use seed::prelude::*;
+use serde::{Deserialize, Serialize};
 
 // Model
 
@@ -24,7 +23,7 @@ impl Car {
     /// _Note_:
     /// Optional feature "wasm-bindgen" has to be enabled for crate `rand` (otherwise it panics).
     fn generate_speed() -> f64 {
-        thread_rng().gen_range(400.0, 800.0)
+        thread_rng().gen_range(400., 800.)
     }
 
     fn generate_color() -> CarColor {
@@ -35,14 +34,14 @@ impl Car {
 
 impl Default for Car {
     fn default() -> Self {
-        let car_width = 120.0;
+        let car_width = 120.;
         Self {
             x: -car_width,
-            y: 100.0,
+            y: 100.,
             speed: Self::generate_speed(),
             color: Self::generate_color(),
             width: car_width,
-            height: 60.0,
+            height: 60.,
         }
     }
 }
@@ -88,13 +87,13 @@ fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
         Msg::OnAnimationFrame(time) => {
             let delta = match model.previous_time {
                 Some(previous_time) => time - previous_time,
-                None => 0.0,
+                None => 0.,
             };
             model.previous_time = Some(time);
 
-            if delta > 0.0 {
+            if delta > 0. {
                 // move car at least 1px to the right
-                model.car.x += f64::max(1.0, delta / 1000.0 * model.car.speed);
+                model.car.x += f64::max(1., delta / 1000. * model.car.speed);
 
                 // we don't see car anymore => back to start + generate new color and speed
                 if model.car.x > model.viewport_width {
@@ -108,27 +107,21 @@ fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
 
 // View
 
-fn px(number: impl ToString + Copy) -> String {
-    let mut value = number.to_string();
-    value.push_str("px");
-    value
-}
-
 fn view(model: &Model) -> El<Msg> {
     // scene container + sky
     div![
         style! {
           "overflow" => "hidden";
-          "width" => "100%";
+          "width" => unit!(100, %);
           "position" => "relative";
-          "height" => "170px";
+          "height" => unit!(170, px);
           "background-color" => "deepskyblue";
         },
         // road
         div![style! {
-            "width" => "100%";
-            "height" => "20px";
-            "bottom" => "0";
+            "width" => unit!(100, %);
+            "height" => unit!(20, px);
+            "bottom" => 0;
             "background-color" => "darkgray";
             "position" => "absolute";
         }],
@@ -140,44 +133,44 @@ fn view_car(car: &Car) -> El<Msg> {
     div![
         // car container
         style! {
-            "width" => px(car.width);
-            "height" => px(car.height);
-            "top" => px(car.y);
-            "left" => px(car.x);
+            "width" => unit!(car.width, px);
+            "height" => unit!(car.height, px);
+            "top" => unit!(car.y, px);
+            "left" => unit!(car.x, px);
             "position" => "absolute";
         },
         // windows
         div![style! {
             "background-color" => "rgb(255,255,255,0.5)";
-            "left" => px(car.width * 0.25);
-            "width" => px(car.width * 0.50);
-            "height" => px(car.height * 0.60);
-            "border-radius" => "9999px";
+            "left" => unit!(car.width * 0.25, px);
+            "width" => unit!(car.width * 0.5, px);
+            "height" => unit!(car.height * 0.6, px);
+            "border-radius" => unit!(9999, px);
             "position" => "absolute";
         }],
         // body
         div![style! {
-            "top" => px(car.height * 0.35);
+            "top" => unit!(car.height * 0.35, px);
             "background-color" => car.color;
-            "width" => px(car.width);
-            "height" => px(car.height * 0.50);
-            "border-radius" => "9999px";
+            "width" => unit!(car.width, px);
+            "height" => unit!(car.height * 0.5, px);
+            "border-radius" => unit!(9999, px);
             "position" => "absolute";
         }],
         view_wheel(car.width * 0.15, car),
-        view_wheel(car.width * 0.60, car)
+        view_wheel(car.width * 0.6, car)
     ]
 }
 
 fn view_wheel(wheel_x: f64, car: &Car) -> El<Msg> {
-    let wheel_radius = car.height * 0.40;
+    let wheel_radius = car.height * 0.4;
     div![style! {
-        "top" => px(car.height * 0.55);
-        "left" => px(wheel_x);
+        "top" => unit!(car.height * 0.55, px);
+        "left" => unit!(wheel_x, px);
         "background-color" => "black";
-        "width" => px(wheel_radius);
-        "height" => px(wheel_radius);
-        "border-radius" => "9999px";
+        "width" => unit!(wheel_radius, px);
+        "height" => unit!(wheel_radius, px);
+        "border-radius" => unit!(9999, px);
         "position" => "absolute";
     }]
 }

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -75,8 +75,8 @@ fn view(model: &Model) -> El<Msg> {
             style! {
                 // Example of conditional logic in a style.
                 "color" => if model.count > 4 {"purple"} else {"gray"};
-                // When passing numerical values to style!, "px" is implied.
-                "border" => "2px solid #004422"; "padding" => 20
+                "border" => "2px solid #004422";
+                "padding" => unit!(20, px);
             },
             // We can use normal Rust code and comments in the view.
             h3![text, did_update(|_| log!("This shows when we increment"))],
@@ -85,7 +85,7 @@ fn view(model: &Model) -> El<Msg> {
             // Optionally-displaying an element, and lifecycle hooks
             if model.count >= 10 {
                 h2![
-                    style! {"padding" => 50},
+                    style! {"padding" => px(50)},
                     "Nice!",
                     did_mount(|_| log!("This shows when clicks reach 10")),
                     will_unmount(|_| log!("This shows when clicks drop below 10")),

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -69,9 +69,9 @@ fn view(model: &Model) -> impl ElContainer<Msg> {
             "display" => "flex";
             "justify-content" => "center";
             "align-items" => "center";
-            "font-size" => "5vmin";
+            "font-size" => vmin(5);
             "font-family" => "sans-serif";
-            "height" => "50vmin";
+            "height" => vmin(50);
         ],
         if model.greet_clicked {
             h1![model.title]
@@ -79,10 +79,10 @@ fn view(model: &Model) -> impl ElContainer<Msg> {
             div![
                 style![
                     "background-color" => "lightgreen";
-                    "padding" => "3vmin";
-                    "border-radius" => "3vmin";
+                    "padding" => vmin(3);
+                    "border-radius" => vmin(3);
                     "cursor" => "pointer";
-                    "box-shadow" => "0 0.5vmin 0.5vmin green";
+                    "box-shadow" => [vmin(0), vmin(0.5), vmin(0.5), "green".into()].join(" ");
                 ],
                 simple_ev(Ev::Click, Msg::Greet),
                 "Greet!"

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -83,7 +83,7 @@ fn view(model: &Model) -> impl ElContainer<Msg> {
     div![
         style! {
             "font-family" => "sans-serif";
-            "max-width" => 460;
+            "max-width" => px(460);
             "margin" => "auto";
         },
         examples
@@ -94,7 +94,7 @@ fn view_example_introduction(title: &str, description: &str) -> Vec<El<Msg>> {
     vec![
         hr![],
         h2![title],
-        div![style! {"margin-bottom" => 15;}, description],
+        div![style! {"margin-bottom" => px(15);}, description],
     ]
 }
 

--- a/examples/server_interaction_detailed/reports/src/lib.rs
+++ b/examples/server_interaction_detailed/reports/src/lib.rs
@@ -132,10 +132,10 @@ fn mx_effectivity(
             0 => num as f32 / lines_filtered.len() as f32,
             _ => 0.,
         };
-        (val * 100.).to_string() + &"%"
+        unit!(val * 100., %)
     };
 
-    let margin_style = style! {"margin-right" => 60};
+    let margin_style = style! {"margin-right" => px(60)};
 
     let display_block = |val: usize, title: &str| {
         div![
@@ -147,12 +147,12 @@ fn mx_effectivity(
     };
 
     section![
-        style! {"margin-bottom" => 100},
+        style! {"margin-bottom" => px(100)},
         h2!["Maintenance line effectivity"],
         div![
             style! {"display" => "flex"; "flex-direction" => "column"},
             div![
-                style! {"display" => "flex"; "margin-bottom" => 60},
+                style! {"display" => "flex"; "margin-bottom" => px(60)},
                 h3!["Start"],
                 h3!["End"],
             ],
@@ -273,7 +273,7 @@ fn sortie_types(lines: &Vec<Line>, people: &Vec<Person>, missions: &Vec<Mission>
     }
 
     section![
-        style! {"margin-bottom" => 100},
+        style! {"margin-bottom" => px(100)},
         h2!["Sortie types (last 60 days)"],
         table![
             class![

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -41,8 +41,8 @@ fn view(model: &Model) -> El<Msg> {
     h1![
         style![
             "text-align" => "center";
-            "margin-top" => "40vmin";
-            "font-size" => "10vmin";
+            "margin-top" => unit!(40, vmin);
+            "font-size" => unit!(10, vmin);
             "font-family" => "monospace";
         ],
         model.time_from_js.clone().unwrap_or_default()

--- a/src/css_units.rs
+++ b/src/css_units.rs
@@ -1,0 +1,144 @@
+//! [MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Values_and_units)
+
+macro_rules! create_unit_items {
+    { $( $variant:tt => $function:tt => $literal_unit:tt ),* $(,)?} => {
+        // ---- Create macro `unit!` ----
+        #[macro_export]
+        macro_rules! unit {
+            { $value:expr } => {
+                {
+                    $value.to_string()
+                }
+             };
+             $(
+                { $value:expr, $literal_unit } => {
+                    {
+                        $value.to_string() + stringify!($literal_unit)
+                    }
+                 };
+             )*
+             { $value:expr, $unit:expr } => {
+                {
+                    let unit: Unit = $unit;
+                    format!("{}{}", $value, unit)
+                }
+             };
+        }
+
+        // ---- Create enum `Unit` ----
+        #[allow(dead_code)]
+        #[derive(Clone, Copy)]
+        pub enum Unit {
+            $($variant,)*
+        }
+        impl std::fmt::Display for Unit {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                let text_unit = match self {
+                    $(Unit::$variant => stringify!($literal_unit),)*
+                };
+                write!(f, "{}", text_unit)
+            }
+        }
+
+        // ---- Create unit functions (e.g. `px(..)`) ----
+        $(
+            #[allow(dead_code)]
+            pub fn $function(value: impl std::fmt::Display) -> String {
+                format!("{}{}", value, stringify!($literal_unit))
+            }
+        )*
+    }
+}
+
+// https://flaviocopes.com/css-units/
+// Unit::Variant => function name => literal unit
+create_unit_items! {
+    // Is like ex, but measures the width of 0 (zero).
+    Ch => ch => ch,
+    // Centimeter (maps to 37.8 pixels).
+    Cm => cm => cm,
+    // Value assigned to that element’s font-size, measures the width of the m letter.
+    Em => em => em,
+    // Fraction units, and they are used in CSS Grid to divide space into fractions.
+    Fr => fr => fr,
+    // Is like em, but measures the height of the x letter.
+    Ex => ex => ex,
+    // Inch (maps to 96 pixels).
+    In => inch => in,
+    // Millimeter.
+    Mm => mm => mm,
+    // Pica (1 pica = 12 points).
+    Pc => pc => pc,
+    // Percent.
+    Percent => percent => %,
+    // Point (1 inch = 72 points).
+    Pt => pt => pt,
+    // Pixel.
+    Px => px => px,
+    // Quarter of a millimeter.
+    Q => q => q,
+    // Is similar to em, but uses the root element (html) font-size.
+    Rem => rem => rem,
+    // Viewport height unit represents a percentage of the viewport height.
+    Vh => vh => vh,
+    // Viewport minimum unit represents the minimum between the height or width in terms of percentage.
+    Vmin => vmin => vmin,
+    // Viewport maximum unit represents the maximum between the height or width in terms of percentage.
+    Vmax => vmax => vmax,
+    // Viewport width unit represents a percentage of the viewport width.
+    Vw => vw => vw,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    // ----------------- Macro Unit -----------------
+    #[wasm_bindgen_test]
+    fn variable() {
+        let width = -100;
+        assert_eq!(unit!(width, px), "-100px");
+    }
+
+    #[wasm_bindgen_test]
+    fn expression() {
+        assert_eq!(unit!(100 + 350, px), "450px");
+    }
+
+    #[wasm_bindgen_test]
+    fn without_unit() {
+        assert_eq!(unit!(2.5), "2.5");
+    }
+
+    #[wasm_bindgen_test]
+    fn str_with_variant() {
+        assert_eq!(unit!("68", Unit::Mm), "68mm");
+    }
+
+    #[wasm_bindgen_test]
+    fn percent_unit() {
+        assert_eq!(unit!(15_236.56f64, %), "15236.56%");
+    }
+
+    #[wasm_bindgen_test]
+    fn in_unit_with_negative_zero() {
+        assert_eq!(unit!(-0, in), "0in");
+    }
+
+    // ----------------- Functions -----------------
+    #[wasm_bindgen_test]
+    fn px_function() {
+        assert_eq!(px(15), "15px");
+    }
+
+    #[wasm_bindgen_test]
+    fn inch_function() {
+        assert_eq!(inch(-15.63), "-15.63in");
+    }
+
+    #[wasm_bindgen_test]
+    fn percent_function() {
+        assert_eq!(percent("35"), "35%");
+    }
+}

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -771,18 +771,8 @@ pub struct Style {
 }
 
 impl Style {
-    pub fn new(vals: IndexMap<String, String>) -> Self {
-        let mut new_vals = IndexMap::new();
-        for (key, val) in vals {
-            // Handle automatic conversion to string with "px" appended, for integers.
-            let val_backup = val.clone();
-            match val.parse::<i32>() {
-                Ok(_) => new_vals.insert(key, val_backup + "px"),
-                Err(_) => new_vals.insert(key, val_backup),
-            };
-        }
-
-        Self { vals: new_vals }
+    pub const fn new(vals: IndexMap<String, String>) -> Self {
+        Self { vals }
     }
 
     pub fn empty() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use wasm_bindgen::{closure::Closure, JsCast};
 #[macro_use]
 pub mod shortcuts;
 
+pub mod css_units;
 pub mod dom_types;
 pub mod fetch;
 mod next_tick;
@@ -79,6 +80,7 @@ pub fn set_timeout(handler: Box<Fn()>, timeout: i32) {
 /// Expose the `wasm_bindgen` prelude, and lifecycle hooks.
 pub mod prelude {
     pub use crate::{
+        css_units::*,
         dom_types::{
             did_mount, did_update, input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev,
             trigger_update_handler, will_unmount, At, El, ElContainer, Ev, MessageMapper,


### PR DESCRIPTION
#127 
Start code review with `src/css_units.rs` - first look at the tests.
It's inspired by your comment https://github.com/David-OConnor/seed/issues/127#issuecomment-500087906.

Changes:
- Helpers for appending units implemented.
- `px` auto appending removed.
- All examples fixed and checked.

First impressions:

**unit!** 
- (+) Seems to be more consistent with other macros like `format!`.
- (+) Unit as suffix is more natural for reading (e.g. `unit!(width, px)`.
- (+) Is suitable for special units (e.g. `unit!(height, %)`) .
- (-) Is a relatively long expression because of macro name.

**px, vmin, ..**
- (+) Short.
- (+) Simple.
- (-) There can be name collisions.
- (-) A little bit less natural to read because of prefix notation (e.g. `px(150 + width)`.
- (-) A little bit awkward for special units (e.g. `percent(..)` for `%` or `inch(..)` for `in` (`in` is Rust keyword)).

So I think we can use both variants.

---

I noticed
```rust
shortcuts::*, // appears not to work.
```
in `/src/lib.rs`.
Does this comment mean that it's not possible to export macros from module `shortcuts`?
Exported macros are declared in the root (if I understand [docs](https://github.com/rust-lang-nursery/reference/blob/master/src/macros-by-example.md#path-based-scope) correctly) so the only option how to get rid of `#[macro_use] extern crate seed;` from projects is to import `*` from `Seed` (I don't know if it's a good idea).