### PR TITLE
fix-macros-and-examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "seed 0.3.6",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -137,7 +135,6 @@ version = "0.1.0"
 dependencies = [
  "seed 0.3.6",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -228,18 +225,6 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.1.0"
-source = "git+https://github.com/rustwasm/gloo#e8e505fbdbe96164381bd6fe7ef350438d54a84f"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -343,7 +328,6 @@ version = "0.1.0"
 dependencies = [
  "seed 0.3.6",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -424,10 +408,8 @@ name = "orders"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "gloo-timers 0.1.0 (git+https://github.com/rustwasm/gloo)",
  "seed 0.3.6",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -673,9 +655,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "seed 0.3.6",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -759,7 +739,6 @@ dependencies = [
  "seed 0.3.6",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -768,9 +747,7 @@ version = "0.1.0"
 dependencies = [
  "seed 0.3.6",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -959,7 +936,6 @@ version = "0.1.0"
 dependencies = [
  "seed 0.3.6",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1084,7 +1060,6 @@ dependencies = [
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "72327b15c228bfe31f1390f93dd5e9279587f0463836393c9df719ce62a3e450"
-"checksum gloo-timers 0.1.0 (git+https://github.com/rustwasm/gloo)" = "<none>"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ wasm-bindgen = {version = "0.2.45", features = ["serde-serialize"]}
 wasm-bindgen-futures = "^0.3.22"
 
 [dependencies.web-sys]
-version = "^0.3.22"
+version = "0.3.22"
 features = [
     "AbortController",
     "AbortSignal",

--- a/examples/animation_frame/Cargo.toml
+++ b/examples/animation_frame/Cargo.toml
@@ -10,7 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 seed = {path = "../../"}
 wasm-bindgen = "0.2.45"
-web-sys = "^0.3.22"
 serde = "^1.0.92"
-serde_derive = "^1.0.92"
 rand = {version = "0.6.5", features = ["wasm-bindgen"]}

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -10,4 +10,3 @@ crate-type = ["cdylib"]
 [dependencies]
 seed = {path = "../../"}
 wasm-bindgen = "0.2.45"
-web-sys = "^0.3.22"

--- a/examples/mathjax/Cargo.toml
+++ b/examples/mathjax/Cargo.toml
@@ -10,4 +10,3 @@ crate-type = ["cdylib"]
 [dependencies]
 seed = {path = "../../"}
 wasm-bindgen = "0.2.45"
-web-sys = "^0.3.22"

--- a/examples/orders/Cargo.toml
+++ b/examples/orders/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 seed = {path = "../../"}
-gloo-timers = { git = "https://github.com/rustwasm/gloo", features = ["futures"] }
+# Can't use repo with a release.
+#gloo-timers = { git = "https://github.com/rustwasm/gloo", features = ["futures"] }
 wasm-bindgen = "0.2.45"
-web-sys = "^0.3.22"
 futures = "^0.1.27"

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -4,7 +4,8 @@
 extern crate seed;
 
 use futures::prelude::*;
-use gloo_timers::future::TimeoutFuture;
+// todo: crate:: here is temporary, until gloo_timers is published.
+use seed::gloo_timers::future::TimeoutFuture;
 use seed::prelude::*;
 
 // Model

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -429,11 +429,8 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "seed 0.3.6",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.1.0",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -663,17 +660,6 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.1.0"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1314,7 +1300,6 @@ dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "gloo-timers 0.1.0",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1384,7 +1369,6 @@ dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-files 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.1.0",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/examples/server_integration/client/Cargo.toml
+++ b/examples/server_integration/client/Cargo.toml
@@ -11,10 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 seed = { path = "../../../" }
 serde = "^1.0.92"
-serde_derive = "^1.0.92"
-serde_json = "^1.0.39"
 wasm-bindgen = "^0.2.45"
-web-sys = "^0.3.22"
 futures = "^0.1.27"
 
 shared = { path = "../shared"}

--- a/examples/server_integration/server/Cargo.toml
+++ b/examples/server_integration/server/Cargo.toml
@@ -10,6 +10,4 @@ actix-web = "1.0.0"
 actix-files = "0.1.1"
 tokio-timer = "0.2.11"
 
-serde_json = "^1.0.39"
-
 shared = { path = "../shared" }

--- a/examples/server_integration/shared/Cargo.toml
+++ b/examples/server_integration/shared/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Your Name <email@address.com>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "^1.0.92", features = ['derive'] }
+serde = { version = "^1.0.92" }

--- a/examples/server_interaction/Cargo.toml
+++ b/examples/server_interaction/Cargo.toml
@@ -10,8 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 seed = { path = "../../" }
 wasm-bindgen = "^0.2.45"
-web-sys = "^0.3.22"
 
-serde = { version = "^1.0.92", features = ['derive'] }
-serde_json = "^1.0.39"
+serde = { version = "^1.0.92" }
 futures = "^0.1.27"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -11,6 +11,4 @@ crate-type = ["cdylib"]
 [dependencies]
 seed = {path = "../../"}
 wasm-bindgen = "^0.2.45"
-web-sys = "^0.3.22"
-
-serde = { version = "^1.0.92", features = ['derive'] }
+serde = { version = "^1.0.92" }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -2,7 +2,9 @@
 
 #[macro_use]
 extern crate seed;
+use seed::dom_types::Event;
 use seed::prelude::*;
+use seed::storage::Storage;
 use serde::{Deserialize, Serialize};
 
 const ENTER_KEY: u32 = 13;
@@ -49,7 +51,7 @@ struct Model {
     visible: Visible,
     entry_text: String,
     edit_text: String,
-    local_storage: web_sys::Storage,
+    local_storage: Storage,
 }
 
 impl Model {
@@ -106,7 +108,7 @@ enum Msg {
     Destroy(usize),
     Toggle(usize),
     ToggleAll,
-    NewTodo(web_sys::Event),
+    NewTodo(Event),
     EditEntry(String),
 
     EditItem(usize),

--- a/examples/update_from_js/Cargo.toml
+++ b/examples/update_from_js/Cargo.toml
@@ -10,6 +10,4 @@ crate-type = ["cdylib"]
 [dependencies]
 seed = {path = "../../"}
 wasm-bindgen = "0.2.45"
-web-sys = "^0.3.22"
 serde = "^1.0.92"
-serde_derive = "^1.0.92"

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -1,8 +1,7 @@
 #[macro_use]
 extern crate seed;
 use seed::prelude::*;
-#[macro_use]
-extern crate serde_derive;
+use serde::Deserialize;
 
 // Model
 

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -14,8 +14,7 @@ path = "src/server.rs"
 
 [dependencies]
 # common
-serde = "^1.0.92"
-serde_derive = "^1.0.92"
+serde = { version = "^1.0.92", features = ["derive"] }
 serde_json = "^1.0.39"
 
 # server

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 extern crate seed;
-#[macro_use]
-extern crate serde_derive;
 
 use seed::{prelude::*, App};
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsCast;
 use web_sys::{MessageEvent, WebSocket};
 

--- a/examples/websocket/src/json.rs
+++ b/examples/websocket/src/json.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Message from the server to the client.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ServerMessage {

--- a/examples/websocket/src/server.rs
+++ b/examples/websocket/src/server.rs
@@ -1,7 +1,3 @@
-#[macro_use]
-extern crate serde_derive;
-extern crate ws;
-
 use ws::{listen, Handler, Message, Request, Response, Result, Sender};
 
 mod json;

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -10,6 +10,8 @@ use std::fmt;
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys;
 
+pub type Event = web_sys::Event;
+
 pub const UPDATE_TRIGGER_EVENT_ID: &str = "triggerupdate";
 
 pub trait MessageMapper<Ms, OtherMs> {

--- a/src/gloo_timers/future.rs
+++ b/src/gloo_timers/future.rs
@@ -47,7 +47,6 @@ use wasm_bindgen_futures::JsFuture;
 /// );
 /// ```
 #[derive(Debug)]
-#[allow(clippy::all)]  // Clippy's still flagging this for name repetition.
 #[must_use = "futures do nothing unless polled or spawned"]
 pub struct TimeoutFuture {
     id: Option<i32>,

--- a/src/gloo_timers/mod.rs
+++ b/src/gloo_timers/mod.rs
@@ -1,5 +1,7 @@
 //! Dummy file reuqired by Rust's module system
 
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+
 pub mod callback;
 pub mod future;
 pub mod sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,9 @@ pub mod prelude {
             trigger_update_handler, will_unmount, At, El, ElContainer, Ev, MessageMapper,
             Optimize::Key, Tag, UpdateEl,
         },
-        shortcuts::*, // appears not to work.
+        // macros are exported in crate root
+        // https://github.com/rust-lang-nursery/reference/blob/master/src/macros-by-example.md
+        shortcuts::*,
         util::{request_animation_frame, RequestAnimationFrameHandle, RequestAnimationFrameTime},
         vdom::{call_update, Orders},
     };

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,8 +8,10 @@
 extern crate serde;
 extern crate serde_json;
 
+pub type Storage = web_sys::Storage;
+
 #[allow(clippy::module_name_repetitions)]
-pub fn get_storage() -> Option<web_sys::Storage> {
+pub fn get_storage() -> Option<Storage> {
     let window = web_sys::window().unwrap();
 
     match window.local_storage() {
@@ -19,7 +21,7 @@ pub fn get_storage() -> Option<web_sys::Storage> {
 }
 
 /// Create a new store, from a serializable data structure.
-pub fn store_data<T>(storage: &web_sys::Storage, name: &str, data: &T)
+pub fn store_data<T>(storage: &Storage, name: &str, data: &T)
 where
     T: serde::Serialize,
 {


### PR DESCRIPTION
Motivation for this request was errors like this:
```
...
          rust-lld: error: duplicate symbol: __wbindgen_describe___widl_f_resu
lt_DOMException
          >>> defined in C:\Users\Martin\Desktop\hellweb\martinkavik_seed\targ
et\wasm32-unknown-unknown\debug\deps\libweb_sys-ad04f3cde63937fc.rlib(web_sys-
ad04f3cde63937fc.web_sys.6uvz5zel-cgu.0.rcgu.o)
          >>> defined in C:\Users\Martin\Desktop\hellweb\martinkavik_seed\targ
et\wasm32-unknown-unknown\debug\deps\libweb_sys-2dea049ac97f1222.rlib(web_sys-
2dea049ac97f1222.web_sys.3c9d52pg-cgu.0.rcgu.o)

          rust-lld: error: too many errors emitted, stopping now (use -error-l
imit=0 to see all errors)


error: aborting due to previous error

error: Could not compile `counter`.
```
This error is probably caused by fighting between linker / wasm-pack / caching (don't know exactly). But the main reason for this specific error is "dependency leak" from `log!` macro - macro was using `web_sys` inside its definition, so it was necessary to add it in examples and then it causes dependency version conflicts between Seed web_sys and given example web_sys.

There were more errors like this and I saw them only when I changed something in code-base, saved it and then run `cargo make verify`. So I went through the whole code-base and was fixing leaks and removing unnecessary dependencies from examples step by step.
And I've also fixed / resolved some todos from `shortcuts.rs`.

This PR has been rebased on your `gloo_timers` changes and I fixed clippy settings + forward gloo_timers in orders example to local ones. So CI should pass now.