### PR TITLE
tasks publish_dry_run and verify_only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,7 @@ matrix:
 
 script:
   - cargo install --force cargo-make # remove --force in the future (https://github.com/rust-lang/cargo/pull/6798)
-  - cargo make fmt_all_check
-  - cargo make clippy_all
-  - cargo make all
-  - cargo make test_h firefox
+  - cargo make verify_only # includes `test_h firefox`
   - cargo make test_h chrome
 
 # TODO: make it faster ; useful links:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,9 +6,14 @@ RUST_RECURSION_COUNT = "0"
 # ---- GENERAL ----
 
 [tasks.verify]
-description = "Format, lint with Clippy, build and run tests"
+description = "Format, lint with Clippy, build, run tests, simulate publish"
 workspace = false
-dependencies = ["fmt_all", "clippy_all", "all", "test_h_firefox"]
+dependencies = ["fmt_all", "clippy_all", "all", "test_h_firefox", "publish_dry_run"]
+
+[tasks.verify_only]
+description = "Like `verify`, but fails if the code isn't formatted. Primarily for CI."
+workspace = false
+dependencies = ["fmt_all_check", "clippy_all", "all", "test_h_firefox", "publish_dry_run"]
 
 # ---- BUILD ----
 
@@ -78,6 +83,12 @@ dependencies = ["clippy"]
 description = "Lint Seed and all examples with Clippy"
 workspace = false
 dependencies = ["clippy", "clippy_examples"]
+
+[tasks.publish_dry_run]
+description = "Check the crate can be published"
+workspace = false
+command = "cargo"
+args = ["publish", "--dry-run", "--allow-dirty"]
 
 # ---- TEST ----
 


### PR DESCRIPTION
Changes:
- New task `publish_dry_run` - it should prevent _"gloo_timers accidents"_.
- `publish_dry_run` integrated into task `verify`.
- New task `verify_only` - same like `verify` but doesn't make changes, intended to use in CI.
- Updated `.travis.yml` - uses `verify_only`.

I recommend to allow only merge branches to `master` with successful build (if you haven't set it up yet or it isn't GitHub default behavior). Because I've changed `.travis.yml` and I don't know if it pass on the first try. And button like GitLab's one "Merge when pipeline succeeds" is nice if GitHub has it.

---

I don't know how much is releasing annoying for you / error prone - but I saw some `cargo make` [flows](https://github.com/sagiegurari/cargo-make#predefined-flows) which should help with it or we can write custom.
