### PR TITLE
142-comma-for-attrs-and-style

### DIFF
--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -67,23 +67,23 @@ fn write_emoticon_after_delay(emoticon: String) -> impl Future<Item = Msg, Error
 fn view(model: &Model) -> impl ElContainer<Msg> {
     div![
         style![
-            "display" => "flex";
-            "justify-content" => "center";
-            "align-items" => "center";
-            "font-size" => vmin(5);
-            "font-family" => "sans-serif";
-            "height" => vmin(50);
+            "display" => "flex",
+            "justify-content" => "center",
+            "align-items" => "center",
+            "font-size" => vmin(5),
+            "font-family" => "sans-serif",
+            "height" => vmin(50),
         ],
         if model.greet_clicked {
             h1![model.title]
         } else {
             div![
                 style![
-                    "background-color" => "lightgreen";
-                    "padding" => vmin(3);
-                    "border-radius" => vmin(3);
-                    "cursor" => "pointer";
-                    "box-shadow" => [vmin(0), vmin(0.5), vmin(0.5), "green".into()].join(" ");
+                    "background-color" => "lightgreen",
+                    "padding" => vmin(3),
+                    "border-radius" => vmin(3),
+                    "cursor" => "pointer",
+                    "box-shadow" => [vmin(0), vmin(0.5), vmin(0.5), "green".into()].join(" "),
                 ],
                 simple_ev(Ev::Click, Msg::Greet),
                 "Greet!"

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -223,7 +223,7 @@ fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> El<Msg> {
         div![
             class!["view"],
             input![
-                attrs! {At::Class => "toggle"; At::Type => "checkbox"; At::Checked => item.completed },
+                attrs! {At::Class => "toggle", At::Type => "checkbox", At::Checked => item.completed; },
                 simple_ev(Ev::Click, Msg::Toggle(posit))
             ],
             label![simple_ev(Ev::DblClick, Msg::EditItem(posit)), item.title],
@@ -231,7 +231,7 @@ fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> El<Msg> {
         ],
         if item.editing {
             input![
-                attrs! {At::Class => "edit"; At::Value => edit_text},
+                attrs! {At::Class => "edit", At::Value => edit_text},
                 simple_ev(Ev::Blur, Msg::EditSubmit(posit)),
                 input_ev(Ev::Input, Msg::EditChange),
                 keyboard_ev(Ev::KeyDown, move |ev| Msg::EditKeyDown(
@@ -248,8 +248,8 @@ fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> El<Msg> {
 fn selection_li(text: &str, visible: Visible, highlighter: Visible) -> El<Msg> {
     li![a![
         attrs! {
-            At::Class => if visible == highlighter {"selected"} else {""};
-            At::Href => "/".to_string() + &highlighter.to_string();
+            At::Class => if visible == highlighter {"selected"} else {""}
+            At::Href => "/".to_string() + &highlighter.to_string()
         },
         style! {"cursor" => "pointer"},
         text
@@ -311,8 +311,10 @@ fn view(model: &Model) -> Vec<El<Msg>> {
         section![
             class!["main"],
             input![
-                attrs! {At::Id => "toggle-all"; At::Class => "toggle-all"; At::Type => "checkbox";
-                At::Checked => model.active_count() == 0},
+                attrs! {
+                    At::Id => "toggle-all"; At::Class => "toggle-all"; At::Type => "checkbox";
+                    At::Checked => model.active_count() == 0
+                },
                 simple_ev(Ev::Click, Msg::ToggleAll)
             ],
             label![attrs! {At::For => "toggle-all"}, "Mark all as complete"],

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -39,10 +39,10 @@ fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
 fn view(model: &Model) -> El<Msg> {
     h1![
         style![
-            "text-align" => "center";
-            "margin-top" => unit!(40, vmin);
-            "font-size" => unit!(10, vmin);
-            "font-family" => "monospace";
+            "text-align" => "center"
+            "margin-top" => unit!(40, vmin)
+            "font-size" => unit!(10, vmin)
+            "font-family" => "monospace"
         ],
         model.time_from_js.clone().unwrap_or_default()
     ]

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -170,7 +170,7 @@ macro_rules! custom {
 /// Provide a shortcut for creating attributes.
 #[macro_export]
 macro_rules! attrs {
-    { $($key:expr => $value:expr);* $(;)? } => {
+    { $($key:expr => $value:expr $(;)?$(,)?)* } => {
         {
             let mut vals = IndexMap::new();
             $(
@@ -212,7 +212,7 @@ macro_rules! id {
 /// Provide a shortcut for creating styles.
 #[macro_export]
 macro_rules! style {
-    { $($key:expr => $value:expr);* $(;)? } => {
+    { $($key:expr => $value:expr $(;)?$(,)?)* } => {
         {
             let mut vals = IndexMap::new();
             $(


### PR DESCRIPTION
#142 
Soo..  we can use commas, semicolons and nothing (whitespace) as separator.. see examples, weird but seems to work.