### PR TITLE
macro plain!

### DIFF
--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -171,6 +171,13 @@ macro_rules! md {
 }
 
 #[macro_export]
+macro_rules! plain {
+    ($text:expr) => {
+        El::new_text($text)
+    };
+}
+
+#[macro_export]
 macro_rules! custom {
     ( $($part:expr),* $(,)? ) => {
         {


### PR DESCRIPTION
New macro **`plain!`**. It cannot be `text!` like in Elm because of conflict with svg `text!`.

Real-world example:
```rust
fn view_navbar_link<Ms>(&self, route: &route::Route, link_content: impl UpdateEl<El<Ms>>) -> El<Ms> {
    a![
        attrs!{At::Href => route.to_string()},
        link_content
    ]
}

//...

self.view_navbar_link(
    &route::Route::NewArticle,
    vec![
         i![
             class!["ion-compose"]
         ],
         plain!("\u{00A0}New Post")
    ]
),
``` 