### PR TITLE
Fetch - response_data, fetch_string_data, fetch_json_data

### DIFF
--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -746,7 +746,15 @@ impl Attrs {
 
     /// Add multiple values for a single attribute. Useful for classes.
     pub fn add_multiple(&mut self, key: At, items: &[&str]) {
-        self.add(key, &items.join(" "));
+        self.add(
+            key,
+            items
+                .iter()
+                .filter_map(|item| if item.is_empty() { None } else { Some(*item) })
+                .collect::<Vec<&str>>()
+                .join(" ")
+                .as_str(),
+        );
     }
 
     /// Combine with another Attrs
@@ -1627,8 +1635,8 @@ pub mod tests {
     #[wasm_bindgen_test]
     pub fn merge_classes() {
         let node = el_to_websys(a![
-            class!["my_class1", "my_class2"],
-            class!["my_class3"],
+            class!["", "my_class1", "my_class2"],
+            class!["my_class3", "", ""],
             attrs![
                 At::Class => "my_class4 my_class5";
             ]

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -1639,13 +1639,18 @@ pub mod tests {
             class!["my_class3", "", ""],
             attrs![
                 At::Class => "my_class4 my_class5";
+            ],
+            class![
+                "my_class6"
+                "my_class7" => false
+                "my_class8" => 1 == 1
             ]
         ]);
 
         let mut expected = IndexMap::new();
         expected.insert(
             "class".to_string(),
-            "my_class1 my_class2 my_class3 my_class4 my_class5".to_string(),
+            "my_class1 my_class2 my_class3 my_class4 my_class5 my_class6 my_class8".to_string(),
         );
         assert_eq!(expected, get_node_attrs(&node));
     }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -207,11 +207,14 @@ macro_rules! attrs {
 /// Convenience macro. Ideal when there are multiple classes, and no other attrs.
 #[macro_export]
 macro_rules! class {
-    { $($class:expr),* $(,)? } => {
+    { $($class:expr $(=> $predicate:expr)? $(,)?)* } => {
         {
             let mut result = $crate::dom_types::Attrs::empty();
             let mut classes = Vec::new();
             $(
+                $(
+                    if !$predicate { return }
+                )?
                 classes.push($class);
             )*
             result.add_multiple(At::Class, &classes);


### PR DESCRIPTION
Changes (all non-breaking):
- `fetch.rs` - I found out that we don't want to know response, only response data and fail reason in the most cases. You can see how new methods work in practice in `server_interaction` example.
   - type `ResponseDataResult<T>`
   - method `response_data()`
   - method `fetch_string_data()`
   - method `fetch_json_data()`
- refactored examples `server_integration` and `server_interaction`
- empty strings are filtered out in `add_multiple` - see modified test `src/dom_types.rs:1638`. The main reason is conditions in `class!` macro - e.g.: 
```rust
class![ "my_class", if something { "my_other_class" } else { "" }  ]
```

---

I don't know if it's possible but another option how to handle conditional classes would be:
```rust
class!["my_class", something => "my_other_class"]
```
Do we want to create a new issue and try to implement it?
(It's similar to Elm [classList](https://package.elm-lang.org/packages/elm-lang/html/2.0.0/Html-Attributes#classList))