### PR TITLE
fix: missing closure in class!

### DIFF
--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -212,10 +212,13 @@ macro_rules! class {
             let mut result = $crate::dom_types::Attrs::empty();
             let mut classes = Vec::new();
             $(
-                $(
-                    if !$predicate { return }
-                )?
-                classes.push($class);
+                // refactor to labeled block once stable (https://github.com/rust-lang/rust/issues/48594)
+                (||{
+                    $(
+                        if !$predicate { return }
+                    )?
+                    classes.push($class);
+                })();
             )*
             result.add_multiple(At::Class, &classes);
             result


### PR DESCRIPTION
This PR fixes my bug in `class!`. 
It was a very nice bug - I forgot to add `return` into closure so `return` leaks to code that used macro. All tests were passing because test is marked as `passed` if it returns `()`.. I don't know how to prevent it without some weird boilerplate.

P.S. Nice contrib. guide!