### PR TITLE
166-patch-empty-element

### DIFF
--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -514,6 +514,12 @@ macro_rules! make_tags {
 // - https://developer.mozilla.org/en-US/docs/Web/SVG/Element
 // Grouped here by category on Mozilla's pages, linked above.
 make_tags! {
+    // -------- Custom Tags -------- //
+
+    Empty => "empty",
+
+    // -------- Standard HTML Tags -------- //
+
     Address => "address", Article => "article", Aside => "aside", Footer => "footer",
     Header => "header", H1 => "h1",
     H2 => "h2", H3 => "h3", H4 => "h4", H5 => "h5", H6 => "h6",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod gloo_timers;
 /// in ternary operations.
 pub fn empty<Ms>() -> dom_types::El<Ms> {
     // The tag doesn't matter here, but this seems semantically appropriate.
-    let mut el = dom_types::El::empty(dom_types::Tag::Del);
+    let mut el = dom_types::El::empty(dom_types::Tag::Empty);
     el.empty = true;
     el
 }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -550,6 +550,10 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
         // Now purge any existing no-longer-needed children; they're not part of the new vdom.
         //    while let Some(mut child) = old_children_iter.next() {
         for mut child in old_children_iter {
+            if child.empty {
+                continue;
+            }
+
             let child_el_ws = child.el_ws.take().expect("Missing child el_ws");
 
             if let Some(unmount_actions) = &mut child.hooks.will_unmount {
@@ -919,6 +923,10 @@ pub(crate) fn patch<'a, Ms, Mdl, ElC: ElContainer<Ms>>(
     // Now purge any existing no-longer-needed children; they're not part of the new vdom.
     //    while let Some(mut child) = old_children_iter.next() {
     for mut child in old_children_iter {
+        if child.empty {
+            continue;
+        }
+
         let child_el_ws = child.el_ws.take().expect("Missing child el_ws");
 
         // TODO: DRY here between this and earlier in func


### PR DESCRIPTION
#166 

I don't know how to write a proper test for this, because only scenario when it fails for me is:

> I'm able to pretty reliable reproduce it in realworld example:
> 1. Open http://localhost:8000/settings (you have to be logged in)
> 2. Press F5 and immediately click on New Post => panic Missing child el_ws

But the main problem was trying to get DOM node for `empty` element.
So I've added simple conditions into patch algorithm and custom tag `Empty` so it will be at least easier to debug it next time.

---

@David-OConnor 
I think (and if I remember correctly someone's already suggested it) that we should refactor in the future `El` into something like `Node` enum with variants like `Text`, `Empty`, `Html` `Svg`, etc. ; because `Option`s and `bool`s are often time bombs.

@flosse Could you test it, if it resolves that issue for you without any side-effects?