### PR TITLE
Node enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## v0.3.8
+## v0.4.0
+- `ElContainer`, imported in prelude, renamed to `View`. (Breaking)
+- Internal refactor of `El`: Now wrapped in `Node`, along with
+`Empty` and `Text`. Creation macros return `Node(Element)`. (Breaking)
 - Added more SVG element macros
 - Several minor bux fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.8
+- Added more SVG element macros
+- Several minor bux fixes
+
 ## v0.3.7
 - `routes` now accepts `Url` instead of `&Url` (Breaking)
 - Improvements to fetch API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ name = "animation_frame"
 version = "0.1.0"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.3.7",
+ "seed 0.4.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -133,7 +133,7 @@ dependencies = [
 name = "counter"
 version = "0.1.0"
 dependencies = [
- "seed 0.3.7",
+ "seed 0.4.0",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -326,7 +326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mathjax"
 version = "0.1.0"
 dependencies = [
- "seed 0.3.7",
+ "seed 0.4.0",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -408,7 +408,7 @@ name = "orders"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.3.7",
+ "seed 0.4.0",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -604,7 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "seed"
-version = "0.3.7"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -653,7 +653,7 @@ name = "server-interaction"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.3.7",
+ "seed 0.4.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -736,7 +736,7 @@ dependencies = [
 name = "todomvc"
 version = "0.1.0"
 dependencies = [
- "seed 0.3.7",
+ "seed 0.4.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -745,7 +745,7 @@ dependencies = [
 name = "trigger_update_from_js"
 version = "0.1.0"
 dependencies = [
- "seed 0.3.7",
+ "seed 0.4.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -934,7 +934,7 @@ dependencies = [
 name = "websocket"
 version = "0.1.0"
 dependencies = [
- "seed 0.3.7",
+ "seed 0.4.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1000,7 +1000,7 @@ dependencies = [
 name = "window-events"
 version = "0.1.0"
 dependencies = [
- "seed 0.3.7",
+ "seed 0.4.0",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seed"
-version = "0.3.7"
+version = "0.4.0"
 description = "A Rust framework for creating web apps, using WebAssembly"
 authors = ["DavidOConnor <david.alan.oconnor@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ fn update(msg: Msg, model: &mut Model, _orders: &mut Orders<Msg>) {
 // View
 
 /// A simple component.
-fn success_level(clicks: i32) -> El<Msg> {
+fn success_level(clicks: i32) -> Node<Msg> {
     let descrip = match clicks {
         0 ... 5 => "Not very many 🙁",
         6 ... 9 => "I got my first real six-string 😐",
@@ -145,7 +145,7 @@ fn success_level(clicks: i32) -> El<Msg> {
 }
 
 /// The top-level component we pass to the virtual dom.
-fn view(model: &Model) -> El<Msg> {
+fn view(model: &Model) -> impl View<Msg> {
     let plural = if model.count == 1 {""} else {"s"};
 
     // Attrs, Style, Events, and children may be defined separately.

--- a/examples/animation_frame/src/lib.rs
+++ b/examples/animation_frame/src/lib.rs
@@ -107,7 +107,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
 
 // View
 
-fn view(model: &Model) -> El<Msg> {
+fn view(model: &Model) -> Node<Msg> {
     // scene container + sky
     div![
         style! {
@@ -129,7 +129,7 @@ fn view(model: &Model) -> El<Msg> {
     ]
 }
 
-fn view_car(car: &Car) -> El<Msg> {
+fn view_car(car: &Car) -> Node<Msg> {
     div![
         // car container
         style! {
@@ -162,7 +162,7 @@ fn view_car(car: &Car) -> El<Msg> {
     ]
 }
 
-fn view_wheel(wheel_x: f64, car: &Car) -> El<Msg> {
+fn view_wheel(wheel_x: f64, car: &Car) -> Node<Msg> {
     let wheel_radius = car.height * 0.4;
     div![style! {
         "top" => unit!(car.height * 0.55, px);

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -45,7 +45,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
 // View
 
 /// A simple component.
-fn success_level(clicks: i32) -> El<Msg> {
+fn success_level(clicks: i32) -> Node<Msg> {
     let descrip = match clicks {
         0...5 => "Not very many 🙁",
         6...9 => "I got my first real six-string 😐",
@@ -57,7 +57,7 @@ fn success_level(clicks: i32) -> El<Msg> {
 
 /// The top-level component we pass to the virtual dom. Must accept the model as its
 /// only argument, and output has to implement trait `ElContainer`.
-fn view(model: &Model) -> El<Msg> {
+fn view(model: &Model) -> impl ElContainer<Msg> {
     let plural = if model.count == 1 { "" } else { "s" };
     let text = format!("{} {}{} so far", model.count, model.what_we_count, plural);
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -57,7 +57,7 @@ fn success_level(clicks: i32) -> Node<Msg> {
 
 /// The top-level component we pass to the virtual dom. Must accept the model as its
 /// only argument, and output has to implement trait `ElContainer`.
-fn view(model: &Model) -> impl ElContainer<Msg> {
+fn view(model: &Model) -> impl View<Msg> {
     let plural = if model.count == 1 { "" } else { "s" };
     let text = format!("{} {}{} so far", model.count, model.what_we_count, plural);
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -26,7 +26,7 @@ impl Default for Model {
 
 // Update
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 enum Msg {
     Increment,
     Decrement,

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -35,7 +35,7 @@ fn _dirac_3(left: &str, middle: &str, right: &str) -> String {
     )
 }
 
-fn view(_: &Model) -> impl ElContainer<Msg> {
+fn view(_: &Model) -> impl View<Msg> {
     vec![
         h1!["Linear algebra cheatsheet"],
         p!["Intent: Provide a quick reference of definitions and identities that 

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -23,7 +23,7 @@ struct Msg;
 
 // View
 
-fn definition(description: &str, def: &str) -> El<Msg> {
+fn definition(description: &str, def: &str) -> Node<Msg> {
     // todo: Could add $$ here.
     div![h5![description], span![format!("$${}$$", def)],]
 }
@@ -35,7 +35,7 @@ fn _dirac_3(left: &str, middle: &str, right: &str) -> String {
     )
 }
 
-fn view(_: &Model) -> Vec<El<Msg>> {
+fn view(_: &Model) -> impl ElContainer<Msg> {
     vec![
         h1!["Linear algebra cheatsheet"],
         p!["Intent: Provide a quick reference of definitions and identities that 

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -64,7 +64,7 @@ fn write_emoticon_after_delay(emoticon: String) -> impl Future<Item = Msg, Error
 
 // View
 
-fn view(model: &Model) -> impl ElContainer<Msg> {
+fn view(model: &Model) -> impl View<Msg> {
     div![
         style![
             "display" => "flex",

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -427,7 +427,7 @@ name = "client"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.3.7",
+ "seed 0.4.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.1.0",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1295,7 +1295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "seed"
-version = "0.3.7"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/examples/server_integration/client/src/example_a.rs
+++ b/examples/server_integration/client/src/example_a.rs
@@ -61,7 +61,7 @@ fn send_request(new_message: String) -> impl Future<Item = Msg, Error = Msg> {
 
 // View
 
-pub fn view(model: &Model) -> impl ElContainer<Msg> {
+pub fn view(model: &Model) -> impl View<Msg> {
     let message = match &model.response_data {
         None => empty![],
         Some(shared::SendMessageResponseBody {

--- a/examples/server_integration/client/src/example_b.rs
+++ b/examples/server_integration/client/src/example_b.rs
@@ -56,7 +56,7 @@ fn send_request() -> impl Future<Item = Msg, Error = Msg> {
 
 // View
 
-pub fn view(model: &Model) -> impl ElContainer<Msg> {
+pub fn view(model: &Model) -> impl View<Msg> {
     vec![
         match &model.response_with_data_result {
             None => empty![],

--- a/examples/server_integration/client/src/example_c.rs
+++ b/examples/server_integration/client/src/example_c.rs
@@ -95,7 +95,7 @@ pub fn view(model: &Model) -> impl ElContainer<Msg> {
 
 fn view_response_data_result(
     response_data_result: &Option<fetch::ResponseDataResult<String>>,
-) -> El<Msg> {
+) -> Node<Msg> {
     match &response_data_result {
         None => empty![],
         Some(Ok(response_data)) => div![format!(r#"Response String body: "{}""#, response_data)],
@@ -103,7 +103,7 @@ fn view_response_data_result(
     }
 }
 
-fn view_fail_reason(fail_reason: &fetch::FailReason) -> El<Msg> {
+fn view_fail_reason(fail_reason: &fetch::FailReason) -> Node<Msg> {
     if let fetch::FailReason::RequestError(fetch::RequestError::DomException(dom_exception)) =
         fail_reason
     {

--- a/examples/server_integration/client/src/example_c.rs
+++ b/examples/server_integration/client/src/example_c.rs
@@ -76,7 +76,7 @@ fn send_request(
 
 // View
 
-pub fn view(model: &Model) -> impl ElContainer<Msg> {
+pub fn view(model: &Model) -> impl View<Msg> {
     match model.status {
         Status::ReadyToSendRequest => vec![
             view_response_data_result(&model.response_data_result),

--- a/examples/server_integration/client/src/example_d.rs
+++ b/examples/server_integration/client/src/example_d.rs
@@ -84,7 +84,7 @@ fn send_request(
 
 // View
 
-pub fn view(model: &Model) -> impl ElContainer<Msg> {
+pub fn view(model: &Model) -> impl View<Msg> {
     match &model.response_result {
         None => vec![
             if let Status::WaitingForResponse(_) = model.status {

--- a/examples/server_integration/client/src/example_d.rs
+++ b/examples/server_integration/client/src/example_d.rs
@@ -102,7 +102,7 @@ pub fn view(model: &Model) -> impl ElContainer<Msg> {
     }
 }
 
-fn view_fail_reason(fail_reason: &fetch::FailReason, status: &Status) -> Vec<El<Msg>> {
+fn view_fail_reason(fail_reason: &fetch::FailReason, status: &Status) -> Vec<Node<Msg>> {
     if let fetch::FailReason::RequestError(fetch::RequestError::DomException(dom_exception)) =
         fail_reason
     {
@@ -114,7 +114,7 @@ fn view_fail_reason(fail_reason: &fetch::FailReason, status: &Status) -> Vec<El<
     vec![]
 }
 
-pub fn view_button(status: &Status) -> El<Msg> {
+pub fn view_button(status: &Status) -> Node<Msg> {
     match status {
         Status::WaitingForResponse(TimeoutStatus::Enabled) => {
             button![simple_ev(Ev::Click, Msg::DisableTimeout), "Disable timeout"]

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -78,7 +78,7 @@ fn view(model: &Model) -> impl ElContainer<Msg> {
     ]
     .into_iter()
     .flatten()
-    .collect::<Vec<El<Msg>>>();
+    .collect::<Vec<Node<Msg>>>();
 
     div![
         style! {
@@ -90,7 +90,7 @@ fn view(model: &Model) -> impl ElContainer<Msg> {
     ]
 }
 
-fn view_example_introduction(title: &str, description: &str) -> Vec<El<Msg>> {
+fn view_example_introduction(title: &str, description: &str) -> Vec<Node<Msg>> {
     vec![
         hr![],
         h2![title],

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -53,7 +53,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
 
 // View
 
-fn view(model: &Model) -> impl ElContainer<Msg> {
+fn view(model: &Model) -> impl View<Msg> {
     let examples = vec![
         // example_a
         view_example_introduction(example_a::TITLE, example_a::DESCRIPTION),

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -127,7 +127,7 @@ fn send_message() -> impl Future<Item = Msg, Error = Msg> {
         .fetch_json_data(Msg::MessageSent)
 }
 
-fn view(model: &Model) -> Vec<El<Msg>> {
+fn view(model: &Model) -> Vec<Node<Msg>> {
     vec![
         div![format!(
             "Repo info: Name: {}, SHA: {}",

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -287,7 +287,7 @@ fn footer(model: &Model) -> Node<Msg> {
 }
 
 // Top-level component we pass to the virtual dom. Must accept the model as its only argument.
-fn view(model: &Model) -> impl ElContainer<Msg> {
+fn view(model: &Model) -> impl View<Msg> {
     // We use the item's position in model.todos to identify it, because this allows
     // simple in-place modification through indexing. This is different from its
     // position in visible todos, hence the two-step process.

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -209,7 +209,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
 
 // View
 
-fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> El<Msg> {
+fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> Node<Msg> {
     let mut att = attrs! {};
     if item.completed {
         att.add(At::Class, "completed");
@@ -245,7 +245,7 @@ fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> El<Msg> {
     ]
 }
 
-fn selection_li(text: &str, visible: Visible, highlighter: Visible) -> El<Msg> {
+fn selection_li(text: &str, visible: Visible, highlighter: Visible) -> Node<Msg> {
     li![a![
         attrs! {
             At::Class => if visible == highlighter {"selected"} else {""}
@@ -256,7 +256,7 @@ fn selection_li(text: &str, visible: Visible, highlighter: Visible) -> El<Msg> {
     ]]
 }
 
-fn footer(model: &Model) -> El<Msg> {
+fn footer(model: &Model) -> Node<Msg> {
     let optional_s = if model.todos.len() == 1 { "" } else { "s" };
 
     let clear_button = if model.completed_count() > 0 {
@@ -287,11 +287,11 @@ fn footer(model: &Model) -> El<Msg> {
 }
 
 // Top-level component we pass to the virtual dom. Must accept the model as its only argument.
-fn view(model: &Model) -> Vec<El<Msg>> {
+fn view(model: &Model) -> impl ElContainer<Msg> {
     // We use the item's position in model.todos to identify it, because this allows
     // simple in-place modification through indexing. This is different from its
     // position in visible todos, hence the two-step process.
-    let todo_els: Vec<El<Msg>> = model
+    let todo_els: Vec<Node<Msg>> = model
         .todos
         .clone()
         .into_iter()

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -240,7 +240,7 @@ fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> Node<Msg> {
                 )),
             ]
         } else {
-            seed::empty()
+            empty![]
         }
     ]
 }

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -36,7 +36,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
 
 // View
 
-fn view(model: &Model) -> El<Msg> {
+fn view(model: &Model) -> Node<Msg> {
     h1![
         style![
             "text-align" => "center"

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -116,7 +116,7 @@ fn register_handlers(ws: &web_sys::WebSocket) {
 
 fn register_message_listener<ElC>(ws: web_sys::WebSocket, app: &App<Msg, Model, ElC>)
 where
-    ElC: ElContainer<Msg> + 'static,
+    ElC: View<Msg> + 'static,
 {
     app.add_message_listener(move |msg| {
         if let Msg::Send(msg) = msg {

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -53,7 +53,7 @@ fn update(msg: Msg, mut model: &mut Model, orders: &mut Orders<Msg>) {
     }
 }
 
-fn view(model: &Model) -> Vec<El<Msg>> {
+fn view(model: &Model) -> Vec<Node<Msg>> {
     vec![
         h1!["seed websocket example"],
         if model.connected {

--- a/examples/window_events/src/lib.rs
+++ b/examples/window_events/src/lib.rs
@@ -40,7 +40,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
 
 /// This func demonstrates use of custom element tags, and the class! and
 /// id! convenience macros
-fn misc_demo() -> El<Msg> {
+fn misc_demo() -> Node<Msg> {
     let custom_el = El::empty(Tag::Custom("mytag".into())).add_text(""); // Demo of add_text.
 
     let mut attributes = attrs! {};
@@ -56,7 +56,7 @@ fn misc_demo() -> El<Msg> {
     ]
 }
 
-fn view(model: &Model) -> Vec<El<Msg>> {
+fn view(model: &Model) -> Vec<Node<Msg>> {
     vec![
         h2![model.coords_string()],
         h2![format!("Last key pressed: {}", model.last_keycode)],

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -946,6 +946,12 @@ impl<Ms> El<Ms> {
         self
     }
 
+    /// Add a new listener
+    pub fn add_listener(mut self, listener: Listener<Ms>) -> Self {
+        self.listeners.push(listener);
+        self
+    }
+
     /// Add a text node to the element. (ie between the HTML tags).
     pub fn add_text(mut self, text: &str) -> Self {
         // todo: Allow text to be impl ToString?

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -119,7 +119,7 @@ impl<Ms> UpdateEl<El<Ms>> for WillUnmount<Ms> {
 impl<Ms> UpdateEl<El<Ms>> for &str {
     // This, or some other mechanism seems to work for String too... note sure why.
     fn update(self, el: &mut El<Ms>) {
-        el.children.push(Node::Text(Text::new(self.into())))
+        el.children.push(Node::Text(Node::new_text(self.into())))
     }
 }
 
@@ -717,6 +717,12 @@ pub enum Node<Ms: 'static> {
     Empty,
 }
 
+impl<Ms> Node<Ms> {
+    pub fn new_text(text: impl ToString) -> Self {
+        Node::Node::new_text(text.to_string())
+    }
+}
+
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
     type SelfWithOtherMs = Node<OtherMs>;
     /// See note on impl for El
@@ -865,12 +871,6 @@ impl<Ms> El<Ms> {
         }
     }
 
-    //    pub fn new_text(text: &str) -> Self {
-    //        let mut result = Self::empty(Tag::Span);
-    //        result.text = Some(text.into());
-    //        result
-    //    }
-
     /// Create an empty SVG element, specifying only the tag
     pub fn empty_svg(tag: Tag) -> Self {
         let mut el = El::empty(tag);
@@ -955,7 +955,7 @@ impl<Ms> El<Ms> {
     /// Add a text node to the element. (ie between the HTML tags).
     pub fn add_text(mut self, text: &str) -> Self {
         // todo: Allow text to be impl ToString?
-        self.children.push(Node::Text(Text::new(text.into())));
+        self.children.push(Node::Text(Node::new_text(text.into())));
         self
     }
 
@@ -978,7 +978,7 @@ impl<Ms> El<Ms> {
         }
         self.children = non_text_children;
 
-        self.children.push(Node::Text(Text::new(text.into())));
+        self.children.push(Node::Text(Node::new_text(text.into())));
         self
     }
 

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -8,7 +8,7 @@ use crate::{
 use core::convert::AsRef;
 use indexmap::IndexMap;
 use pulldown_cmark;
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use web_sys;
 
 pub trait MessageMapper<Ms, OtherMs> {
@@ -119,7 +119,7 @@ impl<Ms> UpdateEl<El<Ms>> for WillUnmount<Ms> {
 impl<Ms> UpdateEl<El<Ms>> for &str {
     // This, or some other mechanism seems to work for String too... note sure why.
     fn update(self, el: &mut El<Ms>) {
-        el.children.push(Node::Text(Text::new(self.into())))
+        el.children.push(Node::Text(Text::new(self.to_string())))
     }
 }
 
@@ -354,11 +354,24 @@ make_styles! {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Attrs {
     // We use an IndexMap instead of HashMap here, and in Style, to preserve order.
-    pub vals: IndexMap<At, String>,
+    pub vals: IndexMap<At, Cow<'static, str>>,
+}
+
+/// Create an HTML-compatible string representation
+impl fmt::Display for Attrs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let string = self
+            .vals
+            .iter()
+            .map(|(k, v)| format!("{}=\"{}\"", k.as_str(), v))
+            .collect::<Vec<_>>()
+            .join(" ");
+        write!(f, "{}", string)
+    }
 }
 
 impl Attrs {
-    pub const fn new(vals: IndexMap<At, String>) -> Self {
+    pub const fn new(vals: IndexMap<At, Cow<'static, str>>) -> Self {
         Self { vals }
     }
 
@@ -370,24 +383,15 @@ impl Attrs {
 
     /// Convenience function. Ideal when there's one id, and no other attrs.
     /// Generally called with the id! macro.
-    pub fn from_id(name: &str) -> Self {
+    pub fn from_id(name: impl Into<Cow<'static, str>>) -> Self {
         let mut result = Self::empty();
-        result.add(At::Id, name);
+        result.add(At::Id, name.into());
         result
     }
 
-    /// Create an HTML-compatible string representation
-    pub fn to_string(&self) -> String {
-        self.vals
-            .iter()
-            .map(|(k, v)| format!("{}=\"{}\"", k.as_str(), v))
-            .collect::<Vec<_>>()
-            .join(" ")
-    }
-
     /// Add a new key, value pair
-    pub fn add(&mut self, key: At, val: &str) {
-        self.vals.insert(key, val.to_string());
+    pub fn add(&mut self, key: At, val: impl Into<Cow<'static, str>>) {
+        self.vals.insert(key, val.into());
     }
 
     /// Add multiple values for a single attribute. Useful for classes.
@@ -396,10 +400,16 @@ impl Attrs {
             key,
             items
                 .iter()
-                .filter_map(|item| if item.is_empty() { None } else { Some(*item) })
+                .filter_map(|item| {
+                    if item.is_empty() {
+                        None
+                    } else {
+                        #[allow(clippy::useless_asref)]
+                        Some(item.as_ref())
+                    }
+                })
                 .collect::<Vec<&str>>()
-                .join(" ")
-                .as_str(),
+                .join(" "),
         );
     }
 
@@ -408,7 +418,7 @@ impl Attrs {
         for (other_key, other_value) in other.vals {
             match self.vals.get_mut(&other_key) {
                 Some(original_value) => {
-                    Self::merge_attribute_values(&other_key, original_value, other_value);
+                    Self::merge_attribute_values(&other_key, original_value.to_mut(), other_value);
                 }
                 None => {
                     self.vals.insert(other_key, other_value);
@@ -417,13 +427,17 @@ impl Attrs {
         }
     }
 
-    fn merge_attribute_values(key: &At, original_value: &mut String, other_value: String) {
+    fn merge_attribute_values(
+        key: &At,
+        original_value: &mut String,
+        other_value: impl Into<Cow<'static, str>>,
+    ) {
         match key {
             At::Class => {
                 original_value.push(' ');
-                original_value.push_str(&other_value);
+                original_value.push_str(other_value.into().as_ref());
             }
-            _ => *original_value = other_value,
+            _ => *original_value = other_value.into().to_string(),
         }
     }
 }
@@ -433,11 +447,11 @@ impl Attrs {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Style {
     // todo enum for key?
-    pub vals: IndexMap<String, String>,
+    pub vals: IndexMap<Cow<'static, str>, Cow<'static, str>>,
 }
 
 impl Style {
-    pub const fn new(vals: IndexMap<String, String>) -> Self {
+    pub const fn new(vals: IndexMap<Cow<'static, str>, Cow<'static, str>>) -> Self {
         Self { vals }
     }
 
@@ -447,8 +461,8 @@ impl Style {
         }
     }
 
-    pub fn add(&mut self, key: &str, val: &str) {
-        self.vals.insert(key.to_string(), val.to_string());
+    pub fn add(&mut self, key: impl Into<Cow<'static, str>>, val: impl Into<Cow<'static, str>>) {
+        self.vals.insert(key.into(), val.into());
     }
 
     /// Combine with another Style; if there's a conflict, use the other one.
@@ -457,11 +471,11 @@ impl Style {
     }
 }
 
-impl ToString for Style {
-    /// Output style as a string, as would be set in the DOM as the attribute value
-    /// for 'style'. Eg: "display: flex; font-size: 1.5em"
-    fn to_string(&self) -> String {
-        if self.vals.keys().len() > 0 {
+/// Output style as a string, as would be set in the DOM as the attribute value
+/// for 'style'. Eg: "display: flex; font-size: 1.5em"
+impl fmt::Display for Style {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let string = if self.vals.keys().len() > 0 {
             self.vals
                 .iter()
                 .map(|(k, v)| format!("{}:{}", k, v))
@@ -469,7 +483,8 @@ impl ToString for Style {
                 .join(";")
         } else {
             String::new()
-        }
+        };
+        write!(f, "{}", string)
     }
 }
 
@@ -674,7 +689,7 @@ impl<Ms: 'static> View<Ms> for Vec<Node<Ms>> {
 /// For representing text nodes.
 #[derive(Clone, Debug)]
 pub struct Text {
-    pub text: String,
+    pub text: Cow<'static, str>,
     pub node_ws: Option<web_sys::Node>,
 }
 
@@ -685,9 +700,9 @@ impl PartialEq for Text {
 }
 
 impl Text {
-    pub const fn new(text: String) -> Self {
+    pub fn new(text: impl Into<Cow<'static, str>>) -> Self {
         Self {
-            text,
+            text: text.into(),
             node_ws: None,
         }
     }
@@ -712,8 +727,8 @@ impl<Ms> Node<Ms> {
         }
     }
 
-    pub fn new_text(text: &impl ToString) -> Self {
-        Node::Text(Text::new(text.to_string()))
+    pub fn new_text(text: impl Into<Cow<'static, str>>) -> Self {
+        Node::Text(Text::new(text))
     }
 
     /// See `El::from_markdown`
@@ -736,7 +751,11 @@ impl<Ms> Node<Ms> {
     }
 
     /// See `El::add_attr`
-    pub fn add_attr(self, key: String, val: String) -> Self {
+    pub fn add_attr(
+        self,
+        key: impl Into<Cow<'static, str>>,
+        val: impl Into<Cow<'static, str>>,
+    ) -> Self {
         if let Node::Element(el) = self {
             Node::Element(el.add_attr(key, val))
         } else {
@@ -745,7 +764,7 @@ impl<Ms> Node<Ms> {
     }
 
     /// /// See `El::add_class``
-    pub fn add_class(self, name: &str) -> Self {
+    pub fn add_class(self, name: impl Into<Cow<'static, str>>) -> Self {
         if let Node::Element(el) = self {
             Node::Element(el.add_class(name))
         } else {
@@ -754,7 +773,11 @@ impl<Ms> Node<Ms> {
     }
 
     /// See `El::add_style`
-    pub fn add_style(self, key: String, val: String) -> Self {
+    pub fn add_style(
+        self,
+        key: impl Into<Cow<'static, str>>,
+        val: impl Into<Cow<'static, str>>,
+    ) -> Self {
         if let Node::Element(el) = self {
             Node::Element(el.add_style(key, val))
         } else {
@@ -772,7 +795,7 @@ impl<Ms> Node<Ms> {
     }
 
     /// See `El::add_text`
-    pub fn add_text(self, text: &str) -> Self {
+    pub fn add_text(self, text: impl Into<Cow<'static, str>>) -> Self {
         if let Node::Element(el) = self {
             Node::Element(el.add_text(text))
         } else {
@@ -781,7 +804,7 @@ impl<Ms> Node<Ms> {
     }
 
     /// See `El::replace_text`
-    pub fn replace_text(self, text: &str) -> Self {
+    pub fn replace_text(self, text: impl Into<Cow<'static, str>>) -> Self {
         if let Node::Element(el) = self {
             Node::Element(el.replace_text(text))
         } else {
@@ -793,7 +816,7 @@ impl<Ms> Node<Ms> {
     pub fn get_text(&self) -> String {
         match self {
             Node::Element(el) => el.get_text(),
-            Node::Text(text) => (&text.text).to_string(),
+            Node::Text(text) => text.text.to_string(),
             _ => "".to_string(),
         }
     }
@@ -979,29 +1002,41 @@ impl<Ms> El<Ms> {
     }
 
     /// Add an attribute (eg class, or href)
-    pub fn add_attr(mut self, key: String, val: String) -> Self {
-        self.attrs.vals.insert(key.into(), val);
+    pub fn add_attr(
+        mut self,
+        key: impl Into<Cow<'static, str>>,
+        val: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        self.attrs
+            .vals
+            .insert(key.into().as_ref().into(), val.into());
         self
     }
 
     /// Add a class. May be cleaner than `add_attr`
-    pub fn add_class(mut self, name: &str) -> Self {
+    pub fn add_class(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        let name = name.into();
         self.attrs
             .vals
             .entry(At::Class)
             .and_modify(|v| {
+                let v = v.to_mut();
                 if !v.is_empty() {
                     *v += " ";
                 }
-                *v += name;
+                *v += name.as_ref();
             })
-            .or_insert(name.into());
+            .or_insert(name);
         self
     }
 
     /// Add a new style (eg display, or height)
-    pub fn add_style(mut self, key: String, val: String) -> Self {
-        self.style.vals.insert(key, val);
+    pub fn add_style(
+        mut self,
+        key: impl Into<Cow<'static, str>>,
+        val: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        self.style.vals.insert(key.into(), val.into());
         self
     }
 
@@ -1012,17 +1047,16 @@ impl<Ms> El<Ms> {
     }
 
     /// Add a text node to the element. (ie between the HTML tags).
-    pub fn add_text(mut self, text: &str) -> Self {
-        // todo: Allow text to be impl ToString?
-        self.children.push(Node::Text(Text::new(text.into())));
+    pub fn add_text(mut self, text: impl Into<Cow<'static, str>>) -> Self {
+        self.children.push(Node::Text(Text::new(text)));
         self
     }
 
     /// Replace the element's text.
     /// Removes all text nodes from element, then adds the new one.
-    pub fn replace_text(mut self, text: &str) -> Self {
+    pub fn replace_text(mut self, text: impl Into<Cow<'static, str>>) -> Self {
         self.children.retain(|node| !node.is_text());
-        self.children.push(Node::Text(Text::new(text.into())));
+        self.children.push(Node::new_text(text));
         self
     }
 
@@ -1031,7 +1065,7 @@ impl<Ms> El<Ms> {
         self.children
             .iter()
             .filter_map(|child| match child {
-                Node::Text(text_node) => Some(text_node.text.as_str()),
+                Node::Text(text_node) => Some(text_node.text.to_string()),
                 _ => None,
             })
             .collect()

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -651,7 +651,7 @@ make_tags! {
     Style => "style", View => "view",
 
     // A custom placeholder tag, for internal use
-    PlaceHolder => "placeholder"
+    Placeholder => "placeholder"
 }
 
 pub trait View<Ms: 'static> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@ pub use crate::{
     fetch::{Method, Request},
     routing::{push_route, Url},
     util::{body, document, error, history, log, update, window},
-    vdom::{find_el, App},
+//    vdom::{find_el, App},
+    vdom::App,
     websys_bridge::{to_html_el, to_input, to_kbevent, to_mouse_event, to_select, to_textarea},
 };
 use wasm_bindgen::{closure::Closure, JsCast};
@@ -31,11 +32,10 @@ pub mod gloo_timers;
 
 /// Create an element flagged in a way that it will not be rendered. Useful
 /// in ternary operations.
-pub fn empty<Ms>() -> dom_types::El<Ms> {
-    // The tag doesn't matter here, but this seems semantically appropriate.
-    let mut el = dom_types::El::empty(dom_types::Tag::Empty);
-    el.empty = true;
-    el
+pub fn empty<Ms>() -> dom_types::Node<Ms> {
+    // todo: Perhaps get rid of this and just use the macro, or replace with
+    // todo exposing Node::Empty directly.
+    dom_types::Node::Empty
 }
 
 /// A high-level wrapper for `web_sys::window.set_interval_with_callback_and_timeout_and_arguments_0`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod dom_types;
 pub mod events;
 pub mod fetch;
 mod next_tick;
+mod patch;
 pub mod routing;
 pub mod storage;
 mod util;
@@ -33,8 +34,6 @@ pub mod gloo_timers;
 /// Create an element flagged in a way that it will not be rendered. Useful
 /// in ternary operations.
 pub fn empty<Ms>() -> dom_types::Node<Ms> {
-    // todo: Perhaps get rid of this and just use the macro, or replace with
-    // todo exposing Node::Empty directly.
     dom_types::Node::Empty
 }
 
@@ -79,8 +78,8 @@ pub mod prelude {
     pub use crate::{
         css_units::*,
         dom_types::{
-            did_mount, did_update, will_unmount, At, El, ElContainer, MessageMapper, Optimize::Key,
-            Tag, UpdateEl,
+            did_mount, did_update, will_unmount, At, El, ElContainer, MessageMapper, Node,
+            Optimize::Key, Tag, UpdateEl,
         },
         events::{
             input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev, trigger_update_handler,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::{
     fetch::{Method, Request},
     routing::{push_route, Url},
     util::{body, document, error, history, log, update, window},
-//    vdom::{find_el, App},
+    //    vdom::{find_el, App},
     vdom::App,
     websys_bridge::{to_html_el, to_input, to_kbevent, to_mouse_event, to_select, to_textarea},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod gloo_timers;
 
 /// Create an element flagged in a way that it will not be rendered. Useful
 /// in ternary operations.
-pub fn empty<Ms>() -> dom_types::Node<Ms> {
+pub const fn empty<Ms>() -> dom_types::Node<Ms> {
     dom_types::Node::Empty
 }
 
@@ -77,8 +77,7 @@ pub mod prelude {
     pub use crate::{
         css_units::*,
         dom_types::{
-            did_mount, did_update, will_unmount, At, El, ElContainer, MessageMapper, Node, Tag,
-            UpdateEl,
+            did_mount, did_update, will_unmount, At, El, MessageMapper, Node, Tag, UpdateEl, View,
         },
         events::{
             input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev, trigger_update_handler,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ pub use crate::{
     fetch::{Method, Request},
     routing::{push_route, Url},
     util::{body, document, error, history, log, update, window},
-    //    vdom::{find_el, App},
     vdom::App,
     websys_bridge::{to_html_el, to_input, to_kbevent, to_mouse_event, to_select, to_textarea},
 };
@@ -137,7 +136,7 @@ pub mod tests {
             }
         }
 
-        fn view(_model: &Model) -> Vec<El<Msg>> {
+        fn view(_model: &Model) -> Vec<Node<Msg>> {
             vec![div!["Hello world"]]
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,8 @@ pub mod prelude {
     pub use crate::{
         css_units::*,
         dom_types::{
-            did_mount, did_update, will_unmount, At, El, ElContainer, MessageMapper, Node,
-            Optimize::Key, Tag, UpdateEl,
+            did_mount, did_update, will_unmount, At, El, ElContainer, MessageMapper, Node, Tag,
+            UpdateEl,
         },
         events::{
             input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev, trigger_update_handler,

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,0 +1,16 @@
+//! This module contains code related to patching the VDOM. It can be considered
+//! a subset of the `vdom` module.
+
+use crate::{dom_types::El, websys_bridge};
+
+/// Remove a node from the vdom and web_sys DOM.
+pub(crate) fn remove_node<Ms>(node: &web_sys::Node, parent: &web_sys::Node, el_vdom: &mut El<Ms>) {
+    websys_bridge::remove_node(node, parent);
+
+    if let Some(unmount_actions) = &mut el_vdom.hooks.will_unmount {
+        (unmount_actions.actions)(node);
+        //                if let Some(message) = unmount_actions.message.clone() {
+        //                    app.update(message);
+        //                }
+    }
+}

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -152,7 +152,7 @@ fn patch_el<'a, Ms, Mdl, ElC: View<Ms>>(
                 (unmount_actions.actions)(old_ws);
             }
 
-            websys_bridge::attach_el_and_children(new, parent, app);
+            websys_bridge::attach_el_and_children(new, parent);
 
             let new_ws = new.node_ws.as_ref().expect("Missing websys el");
             websys_bridge::replace_child(new_ws, old_el_ws, parent);
@@ -231,7 +231,7 @@ fn patch_el<'a, Ms, Mdl, ElC: View<Ms>>(
 
         match child_new {
             Node::Element(child_new_el) => {
-                websys_bridge::attach_el_and_children(child_new_el, &old_el_ws, app);
+                websys_bridge::attach_el_and_children(child_new_el, &old_el_ws);
                 attach_listeners(child_new_el, mailbox);
             }
             Node::Text(child_new_text) => {
@@ -264,14 +264,13 @@ fn patch_el<'a, Ms, Mdl, ElC: View<Ms>>(
 }
 
 // Reduces code repetition
-fn add_el_helper<Ms, Mdl, ElC: View<Ms>>(
+fn add_el_helper<Ms>(
     new: &mut El<Ms>,
     parent: &web_sys::Node,
     next_node: Option<web_sys::Node>,
     mailbox: &Mailbox<Ms>,
-    app: &App<Ms, Mdl, ElC>,
 ) {
-    websys_bridge::attach_children(new, app);
+    websys_bridge::attach_children(new);
     let new_ws = new
         .node_ws
         .take()
@@ -345,7 +344,7 @@ pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>>(
             websys_bridge::assign_ws_nodes(document, new);
             match new {
                 Node::Element(new_el) => {
-                    add_el_helper(new_el, parent, next_node, mailbox, app);
+                    add_el_helper(new_el, parent, next_node, mailbox);
                     new_el.node_ws.as_ref()
                 }
                 Node::Text(new_text) => {
@@ -370,7 +369,7 @@ pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>>(
                         parent,
                     );
 
-                    add_el_helper(new_el, parent, next_node, mailbox, app);
+                    add_el_helper(new_el, parent, next_node, mailbox);
                     new_el.node_ws.as_ref()
                 }
                 Node::Empty => {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,7 +1,84 @@
 //! This module contains code related to patching the VDOM. It can be considered
 //! a subset of the `vdom` module.
 
-use crate::{dom_types::El, websys_bridge};
+use crate::{
+    dom_types::{self, El, ElContainer, Node},
+    events::{self, Listener},
+    vdom::{App, Mailbox},
+    websys_bridge,
+};
+use web_sys::{Document, Window};
+
+/// Recursively attach all event-listeners. Run this after creating fresh elements.
+pub(crate) fn attach_listeners<Ms>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
+    if let Some(el_ws) = el.node_ws.as_ref() {
+        for listener in &mut el.listeners {
+            // todo ideally we unify attach as one method
+            if listener.control_val.is_some() || listener.control_checked.is_some() {
+                listener.attach_control(el_ws);
+            } else {
+                listener.attach(el_ws, mailbox.clone());
+            }
+        }
+    }
+    for child in el.children.iter_mut() {
+        if let Node::Element(child_el) = child {
+            attach_listeners(child_el, mailbox);
+        }
+    }
+}
+
+/// Recursively detach event-listeners. Run this before patching.
+pub(crate) fn detach_listeners<Ms>(el: &mut El<Ms>) {
+    if let Some(el_ws) = el.node_ws.as_ref() {
+        for listener in &mut el.listeners {
+            listener.detach(el_ws);
+        }
+    }
+    for child in &mut el.children {
+        if let Node::Element(child_el) = child {
+            detach_listeners(child_el);
+        }
+    }
+}
+
+/// We reattach all listeners, as with normal Els, since we have no
+/// way of diffing them.
+pub(crate) fn setup_window_listeners<Ms>(
+    window: &Window,
+    old: &mut Vec<Listener<Ms>>,
+    new: &mut Vec<Listener<Ms>>,
+    mailbox: &Mailbox<Ms>,
+) {
+    // todo: Temporary shim to group all events using the same trigger
+    // todo inton one, to prevent them from interupting each other.
+    //    let mut by_trigger = HashMap::new();
+    //    for l in new {
+    //        match by_trigger.contains_key(l.trigger) {
+    //            Some(v) => {
+    //                let new_handlers = hand
+    //                by_trigger.insert(l.trigger, );
+    //            }
+    //        }
+    //    }
+    //
+    //    let grouped_listeners = events::Listener::new(
+    //        |l|
+    //    )
+    //
+    //    let mut new = Vec::new();
+    //    for (trigger, closure) in grouped_listeners {
+    //        new.push(trigger, );
+    //    }
+
+    for listener in old {
+        listener.detach(window);
+    }
+
+    for listener in new {
+        listener.attach(window, mailbox.clone());
+    }
+}
 
 /// Remove a node from the vdom and web_sys DOM.
 pub(crate) fn remove_node<Ms>(node: &web_sys::Node, parent: &web_sys::Node, el_vdom: &mut El<Ms>) {
@@ -12,5 +89,297 @@ pub(crate) fn remove_node<Ms>(node: &web_sys::Node, parent: &web_sys::Node, el_v
         //                if let Some(message) = unmount_actions.message.clone() {
         //                    app.update(message);
         //                }
+    }
+}
+
+/// Set up controlled components: Input, Select, and `TextArea` elements must stay in sync with the
+/// model; don't let them get out of sync from typing or other events, which can occur if a change
+/// doesn't trigger a re-render, or if something else modifies them using a side effect.
+/// Handle controlled inputs: Ie force sync with the model.
+fn setup_input_listener<Ms>(el: &mut El<Ms>)
+    where
+        Ms: 'static,
+{
+    if el.tag == dom_types::Tag::Input
+        || el.tag == dom_types::Tag::Select
+        || el.tag == dom_types::Tag::TextArea
+    {
+        let listener = if let Some(checked) = el.attrs.vals.get(&dom_types::At::Checked) {
+            let checked_bool = match checked.as_ref() {
+                "true" => true,
+                "false" => false,
+                _ => panic!("checked must be true or false."),
+            };
+            events::Listener::new_control_check(checked_bool)
+        } else if let Some(control_val) = el.attrs.vals.get(&dom_types::At::Value) {
+            events::Listener::new_control(control_val.to_string())
+        } else {
+            // If Value is not specified, force the field to be blank.
+            events::Listener::new_control("".to_string())
+        };
+        el.listeners.push(listener); // Add to the El, so we can deattach later.
+    }
+}
+
+/// Recursively sets up input listeners
+pub(crate) fn setup_input_listeners<Ms>(el_vdom: &mut El<Ms>)
+    where
+        Ms: 'static,
+{
+    setup_input_listener(el_vdom);
+    for child in el_vdom.children.iter_mut() {
+        if let Node::Element(child_el) = child {
+            setup_input_listener(child_el);
+        }
+    }
+}
+
+fn patch_el<'a, Ms, Mdl, ElC: ElContainer<Ms>>(
+    document: &Document,
+    mut old: El<Ms>,
+    new: &'a mut El<Ms>,
+    parent: &web_sys::Node,
+    _next_node: Option<web_sys::Node>, // todo remove if the app works without this.
+    mailbox: &Mailbox<Ms>,
+    app: &App<Ms, Mdl, ElC>,
+) -> Option<&'a web_sys::Node> {
+    if old != *new {
+        // At this step, we already assume we have the right element - either
+        // by entering this func directly for the top-level, or recursively after
+        // analyzing children
+
+        // If the tag's different, we must redraw the element and its children; there's
+        // no way to patch one element type into another.
+        // TODO: forcing a rerender for differnet listeners is inefficient
+        // TODO:, but I'm not sure how to patch them.
+
+        // Assume all listeners have been removed from the old el_ws (if any), and the
+        // old el vdom's elements are still attached.
+
+        // Namespaces can't be patched, since they involve create_element_ns instead of create_element.
+        // Something about this element itself is different: patch it.
+        if old.tag != new.tag || old.namespace != new.namespace {
+            let old_el_ws = old.node_ws.as_ref().expect("Missing websys el");;
+
+            websys_bridge::assign_ws_nodes(document, &mut Node::Element(new.clone())); // todo temp clone
+            websys_bridge::attach_el_and_children(new, parent, app);
+
+            let new_el_ws = new.node_ws.as_ref().expect("Missing websys el");
+            websys_bridge::replace_child(new_el_ws, old_el_ws, parent);
+
+            attach_listeners(new, mailbox);
+            // We've re-rendered this child and all children; we're done with this recursion.
+            return new.node_ws.as_ref();
+        } else {
+            // Patch parts of the Element.
+            let old_el_ws = old
+                .node_ws
+                .as_ref()
+                .expect("missing old el_ws when patching non-empty el")
+                .clone();
+            websys_bridge::patch_el_details(&mut old, new, &old_el_ws);
+        }
+    }
+
+    let old_el_ws = old.node_ws.take().unwrap();
+
+    // Before running patch, assume we've removed all listeners from the old element.
+    // Perform this attachment after we've verified we can patch this element, ie
+    // it has the same tag - otherwise  we'd have to detach after the parent.remove_child step.
+    // Note that unlike the attach_listeners function, this only attaches for the current
+    // element.
+    for listener in &mut new.listeners {
+        if listener.control_val.is_some() || listener.control_checked.is_some() {
+            listener.attach_control(&old_el_ws);
+        } else {
+            listener.attach(&old_el_ws, mailbox.clone());
+        }
+    }
+
+    let num_children_in_both = old.children.len().min(new.children.len());
+    let mut old_children_iter = old.children.into_iter();
+    let mut new_children_iter = new.children.iter_mut();
+
+    let mut last_visited_node: Option<web_sys::Node> = None;
+
+    // TODO: Lines below commented out, because they were breaking `lifecycle_hooks` test
+    //       - did_update was called 2x instead of 1x after 2nd call_patch
+    //
+    //  if let Some(update_actions) = &mut new.hooks.did_update {
+    //      (update_actions.actions)(&old_el_ws) // todo
+    //  }
+
+    // Not using .zip() here to make sure we don't miss any of the children when one array is
+    // longer than the other.
+    for _i in 0..num_children_in_both {
+        let child_old = old_children_iter.next().unwrap();
+        let child_new = new_children_iter.next().unwrap();
+
+        // Don't compare equality here; we do that at the top of this function
+        // in the recursion.
+        if let Some(new_el_ws) = patch(
+            document,
+            child_old,
+            child_new,
+            &old_el_ws,
+            match last_visited_node.as_ref() {
+                Some(node) => node.next_sibling(),
+                None => old_el_ws.first_child(),
+            },
+            mailbox,
+            app,
+        ) {
+            last_visited_node = Some(new_el_ws.clone());
+        }
+    }
+
+    // Now one of the iterators is entirely consumed, and any items left in one iterator
+    // don't have any matching items in the other.
+    // We ran out of old children to patch; create new ones.
+    for child_new in new_children_iter {
+        websys_bridge::assign_ws_nodes(document, child_new);
+
+        match child_new {
+            Node::Element(child_new_el) => {
+                websys_bridge::attach_el_and_children(child_new_el, &old_el_ws, app);
+                attach_listeners(child_new_el, mailbox);
+            }
+            Node::Text(child_new_text) => {
+                websys_bridge::attach_text_node(child_new_text, &old_el_ws);
+            }
+            Node::Empty => (),
+        }
+    }
+
+    // Now purge any existing no-longer-needed children; they're not part of the new vdom.
+    // while let Some(mut child) = old_children_iter.next() {
+    for child in old_children_iter {
+        match child {
+            Node::Element(mut child_el) => {
+                let child_ws = child_el.node_ws.take().expect("Missing child el_ws");
+                remove_node(&child_ws, &old_el_ws, &mut child_el);
+                child_el.node_ws.replace(child_ws);
+            }
+            Node::Text(mut child_text) => {
+                let child_ws = child_text.node_ws.take().expect("Missing child node_ws");
+                websys_bridge::remove_node(&child_ws, &old_el_ws);
+                child_text.node_ws.replace(child_ws);
+            }
+            Node::Empty => (),
+        }
+    }
+
+    new.node_ws = Some(old_el_ws);
+    new.node_ws.as_ref()
+}
+
+/// Routes patching through different channels, depending on the Node variant
+/// of old and new.
+pub(crate) fn patch<'a, Ms, Mdl, ElC: ElContainer<Ms>>(
+    document: &Document,
+    old: Node<Ms>,
+    new: &'a mut Node<Ms>,
+    parent: &web_sys::Node,
+    next_node: Option<web_sys::Node>,
+    mailbox: &Mailbox<Ms>,
+    app: &App<Ms, Mdl, ElC>,
+) -> Option<&'a web_sys::Node> {
+    // Old_el_ws is what we're patching, with items from the new vDOM el; or replacing.
+    // We go through each combination of new and old variants to determine how to patch.
+    // We return the resulting web_sys node for assistance in inserting subsequent
+    // ones in the right place.
+
+    // We assume that when we run this, the new vdom doesn't have assigned `web_sys::Node`s -
+    // assign them here when we create them.
+    match old {
+        Node::Element(mut old_el) => {
+            // todo: Move this assign call to the Text arm, once you determine
+            // todo how to satisfy borrow checker.
+            websys_bridge::assign_ws_nodes(document, new);
+            match new {
+                Node::Element(new_el) => {
+                    patch_el(document, old_el, new_el, parent, next_node, mailbox, app)
+                }
+                Node::Text(new_text) => {
+                    let old_node_ws = old_el
+                        .node_ws
+                        .take()
+                        .expect("old el_ws missing when replacing with text node");
+                    let new_node_ws = new_text
+                        .node_ws
+                        .as_ref()
+                        .expect("old el_ws missing when replacing with text node");
+
+                    websys_bridge::replace_child(new_node_ws, &old_node_ws, parent);
+                    new_text.node_ws.as_ref()
+                }
+                Node::Empty => {
+                    let old_el_ws = old_el
+                        .node_ws
+                        .take()
+                        .expect("old el_ws missing when patching Element to Empty");
+                    remove_node(&old_el_ws, parent, &mut old_el);
+                    None
+                }
+            }
+        },
+        Node::Empty => {
+            // If the old node's empty, assign and attach web_sys nodes.
+            websys_bridge::assign_ws_nodes(document, new);
+            match new {
+                Node::Element(new_el) => {
+                    let new_el_ws = new_el
+                        .node_ws
+                        .as_ref()
+                        .expect("new_node_ws missing when patching Empty to Element");
+
+                    websys_bridge::insert_node(&new_el_ws, parent, next_node);
+                    attach_listeners(new_el, mailbox);
+
+                    new_el.node_ws.as_ref()
+                }
+                Node::Text(new_text) => {
+                    let new_node_ws = new_text
+                        .node_ws
+                        .as_ref()
+                        .expect("new_node_ws missing when patching Empty to Text");
+
+                    websys_bridge::insert_node(&new_node_ws, parent, next_node);
+                    new_text.node_ws.as_ref()
+                }
+                // If new and old are empty, we don't need to do anything.
+                Node::Empty => None,
+            }
+        }
+        Node::Text(mut old_text) => match new {
+            Node::Element(new_el) => {
+                websys_bridge::remove_node(
+                    &old_text.node_ws.expect("Can't find node from Text"),
+                    parent,
+                );
+
+                let new_el_ws = new_el.node_ws.take().expect("Missing websys el");
+
+                websys_bridge::insert_node(&new_el_ws, parent, next_node);
+                new_el.node_ws.replace(new_el_ws);
+                new_el.node_ws.as_ref()
+            }
+            Node::Empty => {
+                websys_bridge::remove_node(&old_text.node_ws.expect("Can't find old text"), parent);
+                None
+            }
+            Node::Text(new_text) => {
+                let old_node_ws = old_text
+                    .node_ws
+                    .take()
+                    .expect("old_node_ws missing when changing text");
+
+                if new_text != &old_text {
+                    old_node_ws.set_text_content(Some(&new_text.text));
+                }
+                new_text.node_ws.replace(old_node_ws);
+                new_text.node_ws.as_ref()
+            }
+        },
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -108,7 +108,7 @@ where
     Ms: 'static,
 {
     setup_input_listener(el_vdom);
-    for child in el_vdom.children.iter_mut() {
+    for child in &mut el_vdom.children {
         if let Node::Element(child_el) = child {
             setup_input_listener(child_el);
         }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -25,6 +25,7 @@ macro_rules! element {
                     macro_rules! $Tag {
                         ( $d($d part:expr),* $d(,)? ) => {
                             {
+                                #[allow(unused_mut)]
                                 let mut el = El::empty($crate::dom_types::Tag::$Tag_camel);
                                 $d ( $d part.update(&mut el); )*
                                 $crate::dom_types::Node::Element(el)
@@ -48,6 +49,7 @@ macro_rules! element_svg {
                     macro_rules! $Tag {
                         ( $d($d part:expr),* $d(,)? ) => {
                             {
+                                #[allow(unused_mut)]
                                 let mut el = El::empty_svg($crate::dom_types::Tag::$Tag_camel);
                                 $d ( $d part.update(&mut el); )*
                                 $crate::dom_types::Node::Element(el)

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -162,14 +162,15 @@ macro_rules! raw {
 #[macro_export]
 macro_rules! md {
     ($md:expr) => {
-        El::from_markdown($md)
+        let el = El::from_markdown($md)
+        $crate::dom_types::Node::Element(el)
     };
 }
 
 #[macro_export]
 macro_rules! plain {
     ($text:expr) => {
-        El::new_text($text)
+        $crate::dom_types::Node::new_text($text)
     };
 }
 

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -194,7 +194,7 @@ macro_rules! attrs {
             $(
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.
-                vals.insert($key.into(), $value.to_string());
+                vals.insert($key.into(), $value.to_string().into());
             )*
             $crate::dom_types::Attrs::new(vals)
         }
@@ -242,7 +242,7 @@ macro_rules! style {
             $(
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.
-                vals.insert(String::from($key), $value.to_string());
+                vals.insert($key.into(), $value.to_string().into());
             )*
             $crate::dom_types::Style::new(vals)
         }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -50,7 +50,7 @@ macro_rules! element_svg {
                             {
                                 let mut el = El::empty_svg($crate::dom_types::Tag::$Tag_camel);
                                 $d ( $d part.update(&mut el); )*
-                                el
+                                $crate::dom_types::Node::Element(el)
                             }
                         };
                     }
@@ -179,7 +179,7 @@ macro_rules! custom {
         {
             let mut el = El::empty($crate::dom_types::Tag::Custom("missingtagname".into()));
             $ ( $part.update(&mut el); )*
-            el
+            $crate::dom_types::Node::Element(el)
         }
     };
 }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -27,7 +27,7 @@ macro_rules! element {
                             {
                                 let mut el = El::empty($crate::dom_types::Tag::$Tag_camel);
                                 $d ( $d part.update(&mut el); )*
-                                el
+                                $crate::dom_types::Node::Element(el)
                             }
                         };
                     }
@@ -148,7 +148,7 @@ element_svg! {
 #[macro_export]
 macro_rules! empty {
     () => {
-        $crate::empty()
+        $crate::dom_types::Node::Empty
     };
 }
 

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -13,7 +13,7 @@ use enclose::enclose;
 use next_tick::NextTick;
 
 use crate::{
-    dom_types::{self, El, ElContainer, MessageMapper, Namespace, Node},
+    dom_types::{self, El, MessageMapper, Namespace, Node, View},
     events, next_tick, patch, routing, util, websys_bridge,
 };
 
@@ -191,7 +191,7 @@ pub struct AppCfg<Ms, Mdl, ElC>
 where
     Ms: 'static,
     Mdl: 'static,
-    ElC: ElContainer<Ms>,
+    ElC: View<Ms>,
 {
     document: web_sys::Document,
     mount_point: web_sys::Element,
@@ -204,7 +204,7 @@ pub struct App<Ms, Mdl, ElC>
 where
     Ms: 'static,
     Mdl: 'static,
-    ElC: ElContainer<Ms>,
+    ElC: View<Ms>,
 {
     /// Stateless app configuration
     pub cfg: Rc<AppCfg<Ms, Mdl, ElC>>,
@@ -212,7 +212,7 @@ where
     pub data: Rc<AppData<Ms, Mdl>>,
 }
 
-impl<Ms: 'static, Mdl: 'static, ElC: ElContainer<Ms>> ::std::fmt::Debug for App<Ms, Mdl, ElC> {
+impl<Ms: 'static, Mdl: 'static, ElC: View<Ms>> ::std::fmt::Debug for App<Ms, Mdl, ElC> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "App")
     }
@@ -248,7 +248,7 @@ impl MountPoint for web_sys::HtmlElement {
 
 /// Used to create and store initial app configuration, ie items passed by the app creator
 #[derive(Clone)]
-pub struct AppBuilder<Ms: 'static, Mdl: 'static, ElC: ElContainer<Ms>> {
+pub struct AppBuilder<Ms: 'static, Mdl: 'static, ElC: View<Ms>> {
     model: Mdl,
     update: UpdateFn<Ms, Mdl>,
     view: ViewFn<Mdl, ElC>,
@@ -257,7 +257,7 @@ pub struct AppBuilder<Ms: 'static, Mdl: 'static, ElC: ElContainer<Ms>> {
     window_events: Option<WindowEvents<Ms, Mdl>>,
 }
 
-impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> AppBuilder<Ms, Mdl, ElC> {
+impl<Ms, Mdl, ElC: View<Ms> + 'static> AppBuilder<Ms, Mdl, ElC> {
     /// Choose the element where the application will be mounted.
     /// The default one is the element with `id` = "app".
     ///
@@ -313,7 +313,7 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> AppBuilder<Ms, Mdl, ElC> {
 
 /// We use a struct instead of series of functions, in order to avoid passing
 /// repetitive sequences of parameters.
-impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
+impl<Ms, Mdl, ElC: View<Ms> + 'static> App<Ms, Mdl, ElC> {
     pub fn build(
         model: Mdl,
         update: UpdateFn<Ms, Mdl>,
@@ -569,7 +569,7 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
                     websys_bridge::attach_el_and_children(
                         child_new_el,
                         &self.cfg.mount_point,
-                        &self,
+                        self,
                     );
                     patch::attach_listeners(child_new_el, &self.mailbox());
                 }
@@ -634,7 +634,7 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
     }
 }
 
-impl<Ms, Mdl, ElC: ElContainer<Ms>> Clone for App<Ms, Mdl, ElC> {
+impl<Ms, Mdl, ElC: View<Ms>> Clone for App<Ms, Mdl, ElC> {
     fn clone(&self) -> Self {
         Self {
             cfg: Rc::clone(&self.cfg),
@@ -768,7 +768,6 @@ pub mod tests {
         websys_bridge::assign_ws_nodes(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         if let Node::Element(vdom_el) = vdom.clone() {
-            // todo clone ok here?
             let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
             parent.append_child(&old_ws).unwrap();
 
@@ -834,7 +833,6 @@ pub mod tests {
         websys_bridge::assign_ws_nodes(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         if let Node::Element(vdom_el) = vdom.clone() {
-            // todo clone ok here?
             let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
             parent.append_child(&old_ws).unwrap();
 
@@ -874,7 +872,6 @@ pub mod tests {
         websys_bridge::assign_ws_nodes(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         if let Node::Element(el) = vdom.clone() {
-            // todo clone ok here?
             let old_ws = el.node_ws.as_ref().unwrap().clone();
             parent.append_child(&old_ws).unwrap();
 
@@ -937,7 +934,6 @@ pub mod tests {
         websys_bridge::assign_ws_nodes(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         if let Node::Element(vdom_el) = vdom.clone() {
-            // todo clone ok here?
             let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
             parent.append_child(&old_ws).unwrap();
 
@@ -1020,7 +1016,6 @@ pub mod tests {
         websys_bridge::assign_ws_nodes(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         if let Node::Element(vdom_el) = vdom.clone() {
-            // todo clone ok here?
             let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
             parent.append_child(&old_ws).unwrap();
 
@@ -1072,7 +1067,6 @@ pub mod tests {
         let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         websys_bridge::assign_ws_nodes(&doc, &mut vdom);
         if let Node::Element(vdom_el) = vdom.clone() {
-            // todo clone ok here?
             // clone so we can keep using it after vdom is modified
             let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
             parent.append_child(&old_ws).unwrap();

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -514,7 +514,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static> App<Ms, Mdl, ElC> {
     fn rerender_vdom(&self) {
         // Create a new vdom: The top element, and all its children. Does not yet
         // have associated web_sys elements.
-        let mut new = El::empty(dom_types::Tag::Section);
+        let mut new = El::empty(dom_types::Tag::PlaceHolder);
         new.children = (self.cfg.view)(&self.data.model.borrow()).els();
 
         let mut old = self

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -400,11 +400,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static> App<Ms, Mdl, ElC> {
             for child in &mut new.children {
                 match child {
                     Node::Element(child_el) => {
-                        websys_bridge::attach_el_and_children(
-                            child_el,
-                            &self.cfg.mount_point,
-                            &self,
-                        );
+                        websys_bridge::attach_el_and_children(child_el, &self.cfg.mount_point);
                         patch::attach_listeners(child_el, &self.mailbox());
                     }
                     Node::Text(top_child_text) => {
@@ -566,11 +562,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static> App<Ms, Mdl, ElC> {
             match child_new {
                 Node::Element(child_new_el) => {
                     // We ran out of old children to patch; create new ones.
-                    websys_bridge::attach_el_and_children(
-                        child_new_el,
-                        &self.cfg.mount_point,
-                        self,
-                    );
+                    websys_bridge::attach_el_and_children(child_new_el, &self.cfg.mount_point);
                     patch::attach_listeners(child_new_el, &self.mailbox());
                 }
                 Node::Text(child_new_text) => {

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -130,8 +130,8 @@ impl<Ms: 'static> Orders<Ms> {
     ///orders.perform_cmd(write_emoticon_after_delay());
     /// ```
     pub fn perform_cmd<C>(&mut self, cmd: C) -> &mut Self
-        where
-            C: Future<Item = Ms, Error = Ms> + 'static,
+    where
+        C: Future<Item = Ms, Error = Ms> + 'static,
     {
         self.effects.push_back(Effect::Cmd(Box::new(cmd)));
         self
@@ -185,10 +185,10 @@ pub struct AppData<Ms: 'static, Mdl> {
 }
 
 pub struct AppCfg<Ms, Mdl, ElC>
-    where
-        Ms: 'static,
-        Mdl: 'static,
-        ElC: ElContainer<Ms>,
+where
+    Ms: 'static,
+    Mdl: 'static,
+    ElC: ElContainer<Ms>,
 {
     document: web_sys::Document,
     mount_point: web_sys::Element,
@@ -198,10 +198,10 @@ pub struct AppCfg<Ms, Mdl, ElC>
 }
 
 pub struct App<Ms, Mdl, ElC>
-    where
-        Ms: 'static,
-        Mdl: 'static,
-        ElC: ElContainer<Ms>,
+where
+    Ms: 'static,
+    Mdl: 'static,
+    ElC: ElContainer<Ms>,
 {
     /// Stateless app configuration
     pub cfg: Rc<AppCfg<Ms, Mdl, ElC>>,
@@ -563,7 +563,11 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
             match child_new {
                 Node::Element(child_new_el) => {
                     // We ran out of old children to patch; create new ones.
-                    websys_bridge::attach_el_and_children(child_new_el, &self.cfg.mount_point, &self);
+                    websys_bridge::attach_el_and_children(
+                        child_new_el,
+                        &self.cfg.mount_point,
+                        &self,
+                    );
                     patch::attach_listeners(child_new_el, &self.mailbox());
                 }
                 Node::Text(child_new_text) => {
@@ -596,8 +600,8 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
     }
 
     pub fn add_message_listener<F>(&self, listener: F)
-        where
-            F: Fn(&Ms) + 'static,
+    where
+        F: Fn(&Ms) + 'static,
     {
         self.data
             .msg_listeners
@@ -1358,9 +1362,9 @@ pub mod tests {
             update,
             |_| seed::empty(),
         )
-            .mount(seed::body())
-            .finish()
-            .run();
+        .mount(seed::body())
+        .finish()
+        .run();
 
         // ACT
         app.update(Msg::Start);

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -610,7 +610,7 @@ impl<Ms, Mdl, ElC: ElContainer<Ms> + 'static> App<Ms, Mdl, ElC> {
     }
 
     // todo add back once you sort how to handle with Node refactor
-    //    fn _find(&self, ref_: &str) -> Option<El<Ms>> {
+    //    fn _find(&self, ref_: &str) -> Option<Node<Ms>> {
     //        // todo expensive? We're cloning the whole vdom tree.
     //        // todo: Let's iterate through refs instead, once this is working.
     //
@@ -718,7 +718,7 @@ pub mod tests {
     use crate::{class, prelude::*};
     use futures::future;
     use wasm_bindgen::JsCast;
-    use web_sys::{Node, Text};
+    use web_sys;
 
     #[derive(Clone, Debug)]
     enum Msg {}
@@ -736,19 +736,19 @@ pub mod tests {
         doc: &Document,
         parent: &Element,
         mailbox: &Mailbox<Msg>,
-        old_vdom: El<Msg>,
-        mut new_vdom: El<Msg>,
-        app: &App<Msg, Model, El<Msg>>,
-    ) -> El<Msg> {
+        old_vdom: Node<Msg>,
+        mut new_vdom: Node<Msg>,
+        app: &App<Msg, Model, Node<Msg>>,
+    ) -> Node<Msg> {
         patch(&doc, old_vdom, &mut new_vdom, parent, None, mailbox, &app);
         new_vdom
     }
 
-    fn iter_nodelist(list: web_sys::NodeList) -> impl Iterator<Item = Node> {
+    fn iter_nodelist(list: web_sys::NodeList) -> impl Iterator<Item = web_sys::Node> {
         (0..list.length()).map(move |i| list.item(i).unwrap())
     }
 
-    fn iter_child_nodes(node: &Node) -> impl Iterator<Item = Node> {
+    fn iter_child_nodes(node: &web_sys::Node) -> impl Iterator<Item = web_sys::Node> {
         iter_nodelist(node.child_nodes())
     }
 
@@ -760,7 +760,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = El::empty(seed::dom_types::Tag::Div);
+        let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         let old_ws = vdom.el_ws.as_ref().unwrap().clone();
@@ -821,7 +821,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = El::empty(seed::dom_types::Tag::Div);
+        let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         let old_ws = vdom.node_ws.as_ref().unwrap().clone();
@@ -858,7 +858,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = El::empty(seed::dom_types::Tag::Div);
+        let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         let old_ws = vdom.node_ws.as_ref().unwrap().clone();
@@ -916,7 +916,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = El::empty(seed::dom_types::Tag::Div);
+        let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         let old_ws = vdom.node_ws.as_ref().unwrap().clone();
@@ -994,7 +994,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = El::empty(seed::dom_types::Tag::Div);
+        let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         let old_ws = vdom.node_ws.as_ref().unwrap().clone();
@@ -1042,7 +1042,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = El::empty(seed::dom_types::Tag::Div);
+        let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
         let old_ws = vdom.node_ws.as_ref().unwrap().clone();
@@ -1089,7 +1089,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = seed::empty();
+        let mut vdom = Node::Element(seed::empty());
 
         vdom = call_patch(
             &doc,
@@ -1134,12 +1134,12 @@ pub mod tests {
         let parent = doc.create_element("div").unwrap();
 
         let mut vdom = seed::empty();
-        vdom = call_patch(&doc, &parent, &mailbox, vdom, El::new_text("abc"), &app);
+        vdom = call_patch(&doc, &parent, &mailbox, vdom, Node::new_text("abc"), &app);
         assert_eq!(parent.child_nodes().length(), 1);
         let text = parent
             .first_child()
             .unwrap()
-            .dyn_ref::<Text>()
+            .dyn_ref::<web_sys::Text>()
             .expect("not a Text node")
             .clone();
         assert_eq!(text.text_content().unwrap(), "abc");
@@ -1165,12 +1165,12 @@ pub mod tests {
         assert_eq!(&element.tag_name().to_lowercase(), "span");
 
         // change back to a text node
-        call_patch(&doc, &parent, &mailbox, vdom, El::new_text("abc"), &app);
+        call_patch(&doc, &parent, &mailbox, vdom, Node::new_text("abc"), &app);
         assert_eq!(parent.child_nodes().length(), 1);
         let text = parent
             .first_child()
             .unwrap()
-            .dyn_ref::<Text>()
+            .dyn_ref::<web_sys::Text>()
             .expect("not a Text node")
             .clone();
         assert_eq!(text.text_content().unwrap(), "abc");
@@ -1189,7 +1189,7 @@ pub mod tests {
 
         let mut vdom = seed::empty();
 
-        let node_ref: Rc<RefCell<Option<Node>>> = Default::default();
+        let node_ref: Rc<RefCell<Option<web_sys::Node>>> = Default::default();
         let mount_op_counter: Rc<AtomicUsize> = Default::default();
         let update_counter: Rc<AtomicUsize> = Default::default();
 
@@ -1198,7 +1198,7 @@ pub mod tests {
         let did_mount_func = {
             let node_ref = node_ref.clone();
             let mount_op_counter = mount_op_counter.clone();
-            move |node: &Node| {
+            move |node: &web_sys::Node| {
                 node_ref.borrow_mut().replace(node.clone());
                 assert_eq!(
                     mount_op_counter.fetch_add(1, SeqCst),
@@ -1209,13 +1209,13 @@ pub mod tests {
         };
         let did_update_func = {
             let update_counter = update_counter.clone();
-            move |_node: &Node| {
+            move |_node: &web_sys::Node| {
                 update_counter.fetch_add(1, SeqCst);
             }
         };
         let will_unmount_func = {
             let node_ref = node_ref.clone();
-            move |_node: &Node| {
+            move |_node: &web_sys::Node| {
                 node_ref.borrow_mut().take();
                 // If the counter wasn't 1, then either:
                 // * did_mount wasn't called - we already check this elsewhere

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -514,7 +514,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static> App<Ms, Mdl, ElC> {
     fn rerender_vdom(&self) {
         // Create a new vdom: The top element, and all its children. Does not yet
         // have associated web_sys elements.
-        let mut new = El::empty(dom_types::Tag::PlaceHolder);
+        let mut new = El::empty(dom_types::Tag::Placeholder);
         new.children = (self.cfg.view)(&self.data.model.borrow()).els();
 
         let mut old = self

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -763,7 +763,9 @@ pub mod tests {
         let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
-        let old_ws = vdom.el_ws.as_ref().unwrap().clone();
+        if let Node::Element(vdom_el) = vdom {
+            let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
+        }
         parent.append_child(&old_ws).unwrap();
 
         assert_eq!(parent.children().length(), 1);
@@ -824,30 +826,34 @@ pub mod tests {
         let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
-        let old_ws = vdom.node_ws.as_ref().unwrap().clone();
-        parent.append_child(&old_ws).unwrap();
+        if let Node::Element(vdom_el) = vdom {
+            let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
+            if let Node::Element(vdom_el) = vdom {
+                parent.append_child(&old_ws).unwrap();
 
-        // First add some child nodes using the vdom
-        vdom = call_patch(
-            &doc,
-            &parent,
-            &mailbox,
-            vdom,
-            div!["text", "more text", vec![li!["even more text"]]],
-            &app,
-        );
+                // First add some child nodes using the vdom
+                vdom = call_patch(
+                    &doc,
+                    &parent,
+                    &mailbox,
+                    vdom,
+                    div!["text", "more text", vec![li!["even more text"]]],
+                    &app,
+                );
 
-        assert_eq!(parent.children().length(), 1);
-        assert_eq!(old_ws.child_nodes().length(), 3);
-        let old_child1 = old_ws.child_nodes().item(0).unwrap();
+                assert_eq!(parent.children().length(), 1);
+                assert_eq!(old_ws.child_nodes().length(), 3);
+                let old_child1 = old_ws.child_nodes().item(0).unwrap();
 
-        // Now test that patch function removes the last 2 nodes
-        call_patch(&doc, &parent, &mailbox, vdom, div!["text"], &app);
+                // Now test that patch function removes the last 2 nodes
+                call_patch(&doc, &parent, &mailbox, vdom, div!["text"], &app);
 
-        assert_eq!(parent.children().length(), 1);
-        assert!(old_ws.is_same_node(parent.first_child().as_ref()));
-        assert_eq!(old_ws.child_nodes().length(), 1);
-        assert!(old_child1.is_same_node(old_ws.child_nodes().item(0).as_ref()));
+                assert_eq!(parent.children().length(), 1);
+                assert!(old_ws.is_same_node(parent.first_child().as_ref()));
+                assert_eq!(old_ws.child_nodes().length(), 1);
+                assert!(old_child1.is_same_node(old_ws.child_nodes().item(0).as_ref()));
+            }
+        }
     }
 
     #[wasm_bindgen_test]
@@ -919,7 +925,9 @@ pub mod tests {
         let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
-        let old_ws = vdom.node_ws.as_ref().unwrap().clone();
+        if let Node::Element(vdom_el) = vdom {
+            let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
+        }
         parent.append_child(&old_ws).unwrap();
 
         // First add button without attribute `disabled`
@@ -997,7 +1005,9 @@ pub mod tests {
         let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
         setup_websys_el(&doc, &mut vdom);
         // clone so we can keep using it after vdom is modified
-        let old_ws = vdom.node_ws.as_ref().unwrap().clone();
+        if let Node::Element(vdom_el) = vdom {
+            let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
+        }
         parent.append_child(&old_ws).unwrap();
 
         assert_eq!(parent.children().length(), 1);
@@ -1043,9 +1053,11 @@ pub mod tests {
         let parent = doc.create_element("div").unwrap();
 
         let mut vdom = Node::Element(El::empty(seed::dom_types::Tag::Div));
-        setup_websys_el(&doc, &mut vdom);
+        websys_bridge::make_websys_el(&mut vdom, &doc);
         // clone so we can keep using it after vdom is modified
-        let old_ws = vdom.node_ws.as_ref().unwrap().clone();
+        if let Node::Element(vdom_el) = vdom {
+            let old_ws = vdom_el.node_ws.as_ref().unwrap().clone();
+        }
         parent.append_child(&old_ws).unwrap();
 
         assert_eq!(parent.children().length(), 1);
@@ -1089,7 +1101,7 @@ pub mod tests {
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
 
-        let mut vdom = Node::Element(seed::empty());
+        let mut vdom = seed::empty();
 
         vdom = call_patch(
             &doc,
@@ -1100,7 +1112,9 @@ pub mod tests {
             &app,
         );
         assert_eq!(parent.children().length(), 1);
-        let el_ws = vdom.el_ws.as_ref().expect("el_ws missing");
+        if let Node::Element(vdom_el) = vdom {
+            let el_ws = vdom_el.node_ws.as_ref().expect("el_ws missing");
+        }
         assert!(el_ws.is_same_node(parent.first_child().as_ref()));
         assert_eq!(
             iter_child_nodes(&el_ws)

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -1,6 +1,6 @@
 //! This file contains interactions with `web_sys`.
-use crate::dom_types::{El, Node, Text, View};
-use crate::{dom_types, App};
+use crate::dom_types;
+use crate::dom_types::{El, Node, Text};
 
 use wasm_bindgen::JsCast;
 use web_sys::Document;
@@ -199,10 +199,7 @@ pub fn attach_text_node(text: &mut Text, parent: &web_sys::Node) {
 
 /// Similar to `attach_el_and_children`, but without attaching the elemnt. Useful for
 /// patching, where we want to insert the element at a specific place.
-pub fn attach_children<Ms, Mdl, ElC: View<Ms>>(
-    el_vdom: &mut El<Ms>,
-    app: &App<Ms, Mdl, ElC>, // To avoid inferring type for Mdl.
-) {
+pub fn attach_children<Ms>(el_vdom: &mut El<Ms>) {
     let el_ws = el_vdom
         .node_ws
         .as_ref()
@@ -211,7 +208,7 @@ pub fn attach_children<Ms, Mdl, ElC: View<Ms>>(
     for child in &mut el_vdom.children {
         match child {
             // Raise the active level once per recursion.
-            Node::Element(child_el) => attach_el_and_children(child_el, el_ws, app),
+            Node::Element(child_el) => attach_el_and_children(child_el, el_ws),
             Node::Text(child_text) => attach_text_node(child_text, el_ws),
             Node::Empty => (),
         }
@@ -221,11 +218,7 @@ pub fn attach_children<Ms, Mdl, ElC: View<Ms>>(
 /// Attaches the element, and all children, recursively. Only run this when creating a fresh vdom node, since
 /// it performs a rerender of the el and all children; eg a potentially-expensive op.
 /// This is where rendering occurs.
-pub fn attach_el_and_children<Ms, Mdl, ElC: View<Ms>>(
-    el_vdom: &mut El<Ms>,
-    parent: &web_sys::Node,
-    app: &App<Ms, Mdl, ElC>, // To avoid inferring type for Mdl.
-) {
+pub fn attach_el_and_children<Ms>(el_vdom: &mut El<Ms>, parent: &web_sys::Node) {
     // No parent means we're operating on the top-level element; append it to the main div.
     // This is how we call this function externally, ie not through recursion.
 
@@ -248,7 +241,7 @@ pub fn attach_el_and_children<Ms, Mdl, ElC: View<Ms>>(
     for child in &mut el_vdom.children {
         match child {
             // Raise the active level once per recursion.
-            Node::Element(child_el) => attach_el_and_children(child_el, el_ws, app),
+            Node::Element(child_el) => attach_el_and_children(child_el, el_ws),
             Node::Text(child_text) => attach_text_node(child_text, el_ws),
             Node::Empty => (),
         }
@@ -387,7 +380,7 @@ pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
                         .as_string()
                         .expect("problem converting attr to string");
                     if let Some(attr_val) = el_ws.get_attribute(&attr_name2) {
-                        attrs.add(attr_name2.into(), &attr_val);
+                        attrs.add(attr_name2.into(), attr_val);
                     }
                 });
             result.attrs = attrs;


### PR DESCRIPTION
Big internal refactor, using `Node` as an enum with variants `Element`, `Text`, and `Empty`. Shouldn't change behavior.

Almost ready - need to clean up 2 remaining compile errors, fix tests, and debug.