### PR TITLE
Cow instead of String

### DIFF
--- a/examples/animation_frame/src/lib.rs
+++ b/examples/animation_frame/src/lib.rs
@@ -107,7 +107,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
 
 // View
 
-fn view(model: &Model) -> El<Msg> {
+fn view(model: &Model) -> Node<Msg> {
     // scene container + sky
     div![
         style! {
@@ -129,7 +129,7 @@ fn view(model: &Model) -> El<Msg> {
     ]
 }
 
-fn view_car(car: &Car) -> El<Msg> {
+fn view_car(car: &Car) -> Node<Msg> {
     div![
         // car container
         style! {
@@ -162,7 +162,7 @@ fn view_car(car: &Car) -> El<Msg> {
     ]
 }
 
-fn view_wheel(wheel_x: f64, car: &Car) -> El<Msg> {
+fn view_wheel(wheel_x: f64, car: &Car) -> Node<Msg> {
     let wheel_radius = car.height * 0.4;
     div![style! {
         "top" => unit!(car.height * 0.55, px);

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -53,7 +53,7 @@ fn update(msg: Msg, mut model: &mut Model, orders: &mut Orders<Msg>) {
     }
 }
 
-fn view(model: &Model) -> Vec<El<Msg>> {
+fn view(model: &Model) -> Vec<Node<Msg>> {
     vec![
         h1!["seed websocket example"],
         if model.connected {

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -194,7 +194,7 @@ macro_rules! attrs {
             $(
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.
-                vals.insert($key.into(), $value.to_string());
+                vals.insert($key.into(), $value.to_string().into());
             )*
             $crate::dom_types::Attrs::new(vals)
         }
@@ -242,7 +242,7 @@ macro_rules! style {
             $(
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.
-                vals.insert(String::from($key), $value.to_string());
+                vals.insert($key.into(), $value.to_string().into());
             )*
             $crate::dom_types::Style::new(vals)
         }

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -380,7 +380,7 @@ pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
                         .as_string()
                         .expect("problem converting attr to string");
                     if let Some(attr_val) = el_ws.get_attribute(&attr_name2) {
-                        attrs.add(attr_name2.into(), &attr_val);
+                        attrs.add(attr_name2.into(), attr_val);
                     }
                 });
             result.attrs = attrs;


### PR DESCRIPTION
Changes

- `&str` or `String` in parameters replaced with  `impl Into<Cow<'static, str>>` so it should be a little bit more flexible and efficient
- `impl ToString` and `pub fn ToString` replaced with `impl Display` (see description in https://doc.rust-lang.org/std/string/trait.ToString.html)
- `El<Msg>` replaced with `Node<Msg>` so all examples are buildable

Notes

- I think we can make `Cow<'static, str>` even more efficient once `specialization` is stable. 