### PR TITLE
182-conditional-attrs-styles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ features = [
     "HtmlElement",
     "HtmlCollection",
     "HtmlInputElement",
+    "HtmlMenuItemElement",
     "HtmlTextAreaElement",
     "HtmlSelectElement",
     "HtmlButtonElement",

--- a/examples/server_integration/client/src/example_a.rs
+++ b/examples/server_integration/client/src/example_a.rs
@@ -74,7 +74,10 @@ pub fn view(model: &Model) -> impl View<Msg> {
         message,
         input![
             input_ev(Ev::Input, Msg::NewMessageChanged),
-            attrs! {At::Value => model.new_message}
+            attrs! {
+                At::Value => model.new_message,
+                At::AutoFocus => AtValue::None,
+            }
         ],
         button![simple_ev(Ev::Click, Msg::SendRequest), "Send message"],
     ]

--- a/examples/server_integration/client/src/example_c.rs
+++ b/examples/server_integration/client/src/example_c.rs
@@ -88,7 +88,10 @@ pub fn view(model: &Model) -> impl View<Msg> {
         ],
         Status::RequestAborted => vec![
             view_response_data_result(&model.response_data_result),
-            button![attrs! {At::Disabled => false}, "Request aborted"],
+            button![
+                attrs! {At::Disabled => false.as_at_value()},
+                "Request aborted"
+            ],
         ],
     }
 }

--- a/examples/server_integration/client/src/example_e.rs
+++ b/examples/server_integration/client/src/example_e.rs
@@ -1,0 +1,110 @@
+use futures::Future;
+use seed::fetch;
+use seed::prelude::*;
+use std::mem;
+
+pub const TITLE: &str = "Example E";
+pub const DESCRIPTION: &str =
+    "Write something and click button 'Submit`. It sends form to the server and server returns 200 OK with 2 seconds delay.";
+
+fn get_request_url() -> String {
+    "/api/form".into()
+}
+
+// Model
+
+pub enum Model {
+    ReadyToSubmit(String),
+    WaitingForResponse(String),
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Model::ReadyToSubmit("".into())
+    }
+}
+
+impl Model {
+    fn text(&self) -> &str {
+        match self {
+            Model::ReadyToSubmit(text) | Model::WaitingForResponse(text) => text,
+        }
+    }
+    fn text_mut(&mut self) -> &mut String {
+        match self {
+            Model::ReadyToSubmit(text) | Model::WaitingForResponse(text) => text,
+        }
+    }
+    fn set_text(&mut self, text: String) {
+        match self {
+            Model::ReadyToSubmit(old_text) | Model::WaitingForResponse(old_text) => {
+                *old_text = text
+            }
+        }
+    }
+}
+
+// Update
+
+#[derive(Clone)]
+pub enum Msg {
+    TextChanged(String),
+    FormSubmitted,
+    ServerResponded(fetch::ResponseResult<()>),
+}
+
+pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+    match msg {
+        Msg::TextChanged(text) => model.set_text(text),
+
+        Msg::FormSubmitted => {
+            let text = take(model.text_mut());
+            orders.perform_cmd(send_request(&text));
+            *model = Model::WaitingForResponse(text);
+        }
+
+        Msg::ServerResponded(Ok(_)) => *model = Model::ReadyToSubmit("".into()),
+
+        Msg::ServerResponded(Err(_)) => *model = Model::ReadyToSubmit(take(model.text_mut())),
+    }
+}
+
+#[allow(clippy::ptr_arg)]
+fn send_request(text: &String) -> impl Future<Item = Msg, Error = Msg> {
+    fetch::Request::new(get_request_url())
+        .method(fetch::Method::Post)
+        .send_json(text)
+        .fetch(|fetch_object| Msg::ServerResponded(fetch_object.response()))
+}
+
+fn take<T: Default>(source: &mut T) -> T {
+    mem::replace(source, T::default())
+}
+
+// View
+
+pub fn view(model: &Model) -> impl View<Msg> {
+    let btn_disabled = match model {
+        Model::ReadyToSubmit(text) if !text.is_empty() => false,
+        _ => true,
+    };
+
+    form![
+        raw_ev(Ev::Submit, |event| {
+            event.prevent_default();
+            Msg::FormSubmitted
+        }),
+        input![
+            input_ev(Ev::Input, Msg::TextChanged),
+            attrs! {At::Value => model.text()}
+        ],
+        button![
+            style! {
+                "padding" => format!{"{} {}", px(2), px(12)},
+                "background-color" => if btn_disabled { CSSValue::Ignored } else { "aquamarine".into() },
+            },
+            attrs! {At::Disabled => btn_disabled.as_at_value()},
+            "Submit"
+        ]
+    ]
+}

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -9,6 +9,7 @@ mod example_a;
 mod example_b;
 mod example_c;
 mod example_d;
+mod example_e;
 
 // Model
 
@@ -18,6 +19,7 @@ struct Model {
     example_b: example_b::Model,
     example_c: example_c::Model,
     example_d: example_d::Model,
+    example_e: example_e::Model,
 }
 
 // Update
@@ -28,6 +30,7 @@ enum Msg {
     ExampleB(example_b::Msg),
     ExampleC(example_c::Msg),
     ExampleD(example_d::Msg),
+    ExampleE(example_e::Msg),
 }
 
 fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
@@ -47,6 +50,10 @@ fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
         Msg::ExampleD(msg) => {
             *orders = call_update(example_d::update, msg, &mut model.example_d)
                 .map_message(Msg::ExampleD);
+        }
+        Msg::ExampleE(msg) => {
+            *orders = call_update(example_e::update, msg, &mut model.example_e)
+                .map_message(Msg::ExampleE);
         }
     }
 }
@@ -75,6 +82,11 @@ fn view(model: &Model) -> impl View<Msg> {
         example_d::view(&model.example_d)
             .els()
             .map_message(Msg::ExampleD),
+        // example_e
+        view_example_introduction(example_e::TITLE, example_e::DESCRIPTION),
+        example_e::view(&model.example_e)
+            .els()
+            .map_message(Msg::ExampleE),
     ]
     .into_iter()
     .flatten()

--- a/examples/server_integration/server/src/main.rs
+++ b/examples/server_integration/server/src/main.rs
@@ -36,6 +36,11 @@ fn delayed_response(
         .and_then(move |()| Ok(format!("Delay was set to {}ms.", delay)))
 }
 
+#[post("form")]
+fn form() -> impl Future<Item = (), Error = tokio_timer::Error> {
+    tokio_timer::sleep(time::Duration::from_millis(2_000)).and_then(move |()| Ok(()))
+}
+
 struct State {
     count_actor: Addr<CountActor>,
 }
@@ -53,7 +58,8 @@ fn main() -> std::io::Result<()> {
             .service(
                 web::scope("/api/")
                     .service(send_message)
-                    .service(delayed_response),
+                    .service(delayed_response)
+                    .service(form),
             )
             .service(Files::new("/public", "./client/public"))
             .service(Files::new("/pkg", "./client/pkg"))

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -223,7 +223,11 @@ fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> Node<Msg> {
         div![
             class!["view"],
             input![
-                attrs! {At::Class => "toggle", At::Type => "checkbox", At::Checked => item.completed; },
+                attrs! {
+                   At::Class => "toggle",
+                   At::Type => "checkbox",
+                   At::Checked => item.completed.as_at_value()
+                },
                 simple_ev(Ev::Click, Msg::Toggle(posit))
             ],
             label![simple_ev(Ev::DblClick, Msg::EditItem(posit)), item.title],
@@ -312,8 +316,8 @@ fn view(model: &Model) -> impl View<Msg> {
             class!["main"],
             input![
                 attrs! {
-                    At::Id => "toggle-all"; At::Class => "toggle-all"; At::Type => "checkbox";
-                    At::Checked => model.active_count() == 0
+                    At::Id => "toggle-all"; At::Class => "toggle-all"; At::Type => "checkbox",
+                    At::Checked => (model.active_count() == 0).as_at_value(),
                 },
                 simple_ev(Ev::Click, Msg::ToggleAll)
             ],

--- a/src/dom_types/values.rs
+++ b/src/dom_types/values.rs
@@ -1,0 +1,86 @@
+// ------------- CSSValue -------------
+
+/// CSS property value.
+///
+/// # Example
+///
+/// ```rust,no_run
+///style! {
+///    "padding" => px(12),
+///    "background-color" => if disabled { CSSValue::Ignored } else { "green".into() },
+///    "display" => CSSValue::Some("block".to_string()),
+///}
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CSSValue {
+    /// The whole CSS property is ignored (i.e. not rendered).
+    Ignored,
+    /// Rendered CSS property value.
+    Some(String),
+}
+
+impl<T: ToString> From<T> for CSSValue {
+    fn from(value: T) -> Self {
+        CSSValue::Some(value.to_string())
+    }
+}
+
+// `&` because `style!` macro automatically adds prefix `&` before values for more ergonomic API
+// (otherwise it would fail when you use for example a Model's property in View functions as `CSSValue`)
+impl From<&CSSValue> for CSSValue {
+    fn from(value: &CSSValue) -> Self {
+        value.clone()
+    }
+}
+
+// ------------- AtValue -------------
+
+/// Attribute value.
+///
+/// # Example
+///
+/// ```rust,no_run
+///attrs! {
+///    At::Disabled => false.as_at_value(),  // same as `=> AtValue::Ignored`
+///    At::Value => model.message,
+///    At::AutoFocus => AtValue::None,
+///}
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AtValue {
+    /// The whole attribute is ignored (i.e. not rendered).
+    Ignored,
+    /// Attribute value is not used (i.e. rendered as empty string).
+    None,
+    /// Rendered attribute value.
+    Some(String),
+}
+
+impl<T: ToString> From<T> for AtValue {
+    fn from(value: T) -> Self {
+        AtValue::Some(value.to_string())
+    }
+}
+
+// `&` because `attrs!` macro automatically adds prefix `&` before values for more ergonomic API
+// (otherwise it would fail when you use for example a Model's property in View functions as `AtValue`)
+impl From<&AtValue> for AtValue {
+    fn from(value: &AtValue) -> Self {
+        value.clone()
+    }
+}
+
+// -- AsAtValue --
+
+pub trait AsAtValue {
+    fn as_at_value(&self) -> AtValue;
+}
+
+impl AsAtValue for bool {
+    fn as_at_value(&self) -> AtValue {
+        match self {
+            true => AtValue::None,
+            false => AtValue::Ignored,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,8 @@ pub mod prelude {
     pub use crate::{
         css_units::*,
         dom_types::{
-            did_mount, did_update, will_unmount, At, El, MessageMapper, Node, Tag, UpdateEl, View,
+            did_mount, did_update, will_unmount, AsAtValue, At, AtValue, CSSValue, El,
+            MessageMapper, Node, Tag, UpdateEl, View,
         },
         events::{
             input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev, trigger_update_handler,
@@ -90,7 +91,6 @@ pub mod prelude {
         vdom::{call_update, Orders},
     };
     pub use indexmap::IndexMap; // for attrs and style to work.
-
     pub use wasm_bindgen::prelude::*;
 }
 

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -2,7 +2,7 @@
 //! a subset of the `vdom` module.
 
 use crate::{
-    dom_types::{self, El, Node, View},
+    dom_types::{self, AtValue, El, Node, View},
     events::{self, Listener},
     vdom::{App, Mailbox},
     websys_bridge,
@@ -86,14 +86,15 @@ where
         || el.tag == dom_types::Tag::TextArea
     {
         let listener = if let Some(checked) = el.attrs.vals.get(&dom_types::At::Checked) {
-            let checked_bool = match checked.as_ref() {
-                "true" => true,
-                "false" => false,
-                _ => panic!("checked must be true or false."),
-            };
-            events::Listener::new_control_check(checked_bool)
+            events::Listener::new_control_check(match checked {
+                AtValue::Some(_) => true,
+                _ => false,
+            })
         } else if let Some(control_val) = el.attrs.vals.get(&dom_types::At::Value) {
-            events::Listener::new_control(control_val.to_string())
+            events::Listener::new_control(match control_val {
+                AtValue::Some(value) => value.clone(),
+                _ => "".into(),
+            })
         } else {
             // If Value is not specified, force the field to be blank.
             events::Listener::new_control("".to_string())

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -196,7 +196,8 @@ macro_rules! attrs {
             $(
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.
-                vals.insert($key.into(), $value.to_string().into());
+                // And cases like `true.as_attr_value()` or `AtValue::Ignored`.
+                vals.insert($key.into(), (&$value).into());
             )*
             $crate::dom_types::Attrs::new(vals)
         }
@@ -244,7 +245,8 @@ macro_rules! style {
             $(
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.
-                vals.insert($key.into(), $value.to_string().into());
+                // And cases like `CSSValue::Ignored`.
+                vals.insert($key.into(), (&$value).into());
             )*
             $crate::dom_types::Style::new(vals)
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -61,6 +61,9 @@ pub fn request_animation_frame(
 /// Simplify getting the value of input elements; required due to the need to cast
 /// from general nodes/elements to `HTML_Elements`.
 pub fn get_value(target: &web_sys::EventTarget) -> String {
+    // @TODO support more elements (in get_value and set_value)?
+    // @TODO (https://docs.rs/web-sys/0.3.25/web_sys/struct.HtmlMenuItemElement.html?search=set_value)
+    // @TODO return Result / panic?
     if let Some(input) = target.dyn_ref::<web_sys::HtmlInputElement>() {
         return input.value();
     }
@@ -84,6 +87,31 @@ pub fn set_value(target: &web_sys::EventTarget, value: &str) {
     if let Some(input) = target.dyn_ref::<web_sys::HtmlSelectElement>() {
         return input.set_value(value);
     }
+}
+
+/// Similar to `get_value`
+#[allow(dead_code)]
+pub fn get_checked(target: &web_sys::EventTarget) -> Result<bool, &'static str> {
+    if let Some(input) = target.dyn_ref::<web_sys::HtmlInputElement>() {
+        return Ok(input.checked());
+    }
+    if let Some(input) = target.dyn_ref::<web_sys::HtmlMenuItemElement>() {
+        return Ok(input.checked());
+    }
+    Err("Only `HtmlInputElement` and `HtmlMenuItemElement` can be used in function `get_checked`.")
+}
+
+/// Similar to `set_value`.
+pub fn set_checked(target: &web_sys::EventTarget, value: bool) -> Result<(), &'static str> {
+    if let Some(input) = target.dyn_ref::<web_sys::HtmlInputElement>() {
+        input.set_checked(value);
+        return Ok(());
+    }
+    if let Some(input) = target.dyn_ref::<web_sys::HtmlMenuItemElement>() {
+        input.set_checked(value);
+        return Ok(());
+    }
+    Err("Only `HtmlInputElement` and `HtmlMenuItemElement` can be used in function `set_checked`.")
 }
 
 // todo: Unable to get this convenience function working

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -935,7 +935,7 @@ pub mod tests {
                 &parent,
                 &mailbox,
                 vdom,
-                div![button![attrs! { At::Disabled => false }]],
+                div![button![attrs! { At::Disabled => false.as_at_value() }]],
                 &app,
             );
 
@@ -955,7 +955,7 @@ pub mod tests {
                 &parent,
                 &mailbox,
                 vdom,
-                div![button![attrs! { At::Disabled => true }]],
+                div![button![attrs! { At::Disabled => true.as_at_value() }]],
                 &app,
             );
 
@@ -969,7 +969,7 @@ pub mod tests {
                 button
                     .get_attribute("disabled")
                     .expect("button hasn't got attribute `disabled`!"),
-                "true"
+                ""
             );
 
             // And remove attribute `disabled`
@@ -978,7 +978,7 @@ pub mod tests {
                 &parent,
                 &mailbox,
                 vdom,
-                div![button![attrs! { At::Disabled => false }]],
+                div![button![attrs! { At::Disabled => false.as_at_value() }]],
                 &app,
             );
 

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -1,117 +1,9 @@
 //! This file contains interactions with `web_sys`.
 use crate::dom_types;
-use crate::dom_types::{El, Node, Text};
+use crate::dom_types::{AtValue, El, Node, Text};
 
 use wasm_bindgen::JsCast;
 use web_sys::Document;
-
-/// Add a shim to make check logic more natural than the DOM handles it.
-fn set_attr_shim(el_ws: &web_sys::Node, at: &dom_types::At, val: &str) {
-    // set_special means we don't set the attribute normally.
-    let mut set_special = false;
-    let at = at.as_str();
-
-    if at == "checked" {
-        let input_el = el_ws.dyn_ref::<web_sys::HtmlInputElement>();
-        if let Some(el) = input_el {
-            match val {
-                "true" => {
-                    el.set_checked(true);
-                }
-                "false" => {
-                    el.set_checked(false);
-                }
-                _ => (),
-            }
-            set_special = true;
-        }
-    }
-    // todo DRY! Massive dry between checked and auto, and in autofocus.
-    // https://www.w3schools.com/tags/att_autofocus.asp
-    //todo needs to work for other types of input!
-    else if at == "autofocus" {
-        if let Some(input) = el_ws.dyn_ref::<web_sys::HtmlInputElement>() {
-            //            autofocus_helper(input)
-            match val {
-                "true" => {
-                    input.set_autofocus(true);
-                }
-                "false" => {
-                    input.set_autofocus(false);
-                }
-                _ => (),
-            }
-            set_special = true;
-        }
-        if let Some(input) = el_ws.dyn_ref::<web_sys::HtmlTextAreaElement>() {
-            //             autofocus_helper(input)
-            match val {
-                "true" => {
-                    input.set_autofocus(true);
-                }
-                "false" => {
-                    input.set_autofocus(false);
-                }
-                _ => (),
-            }
-            set_special = true;
-        }
-        if let Some(input) = el_ws.dyn_ref::<web_sys::HtmlSelectElement>() {
-            //             autofocus_helper(input)
-            match val {
-                "true" => {
-                    input.set_autofocus(true);
-                }
-                "false" => {
-                    input.set_autofocus(false);
-                }
-                _ => (),
-            }
-            set_special = true;
-        }
-        if let Some(input) = el_ws.dyn_ref::<web_sys::HtmlButtonElement>() {
-            //             autofocus_helper(input)
-            match val {
-                "true" => {
-                    input.set_autofocus(true);
-                }
-                "false" => {
-                    input.set_autofocus(false);
-                }
-                _ => (),
-            }
-            set_special = true;
-        }
-    }
-    // A disabled value of anything, including "", means disabled. To make not disabled,
-    // the disabled attr can't be present.
-    // Without this shim, setting At::Disabled => false still disables the field.
-    else if at == "disabled" && val == "false" {
-        match el_ws.node_type() {
-            // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
-            1 => el_ws
-                .dyn_ref::<web_sys::Element>()
-                .expect("Problem casting Node as Element while removing the attribute `disabled`")
-                .remove_attribute(at)
-                .expect("Problem removing the atrribute `disabled`."),
-            _ => crate::error("Found non el node while removing attribute `disabled`."),
-        }
-        set_special = true;
-    }
-
-    if !set_special {
-        match el_ws.node_type() {
-            // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
-            1 => el_ws
-                .dyn_ref::<web_sys::Element>()
-                .expect("Problem casting Node as Element while setting an attribute")
-                .set_attribute(at, val)
-                .expect("Problem setting an atrribute."),
-            3 => crate::error("Trying to set attr on text node. Bug?"),
-            _ => crate::error("Found non el/text node."),
-        }
-    }
-}
 
 /// Convenience function to reduce repetition
 fn set_style(el_ws: &web_sys::Node, style: &dom_types::Style) {
@@ -146,6 +38,48 @@ where
     }
 }
 
+fn node_to_element(el_ws: &web_sys::Node) -> Result<&web_sys::Element, &'static str> {
+    if let web_sys::Node::ELEMENT_NODE = el_ws.node_type() {
+        el_ws
+            .dyn_ref::<web_sys::Element>()
+            .ok_or("Problem casting Node as Element")
+    } else {
+        Err("Node isn't Element!")
+    }
+}
+
+fn set_attr_value(el_ws: &web_sys::Node, at: &dom_types::At, at_value: &AtValue) {
+    match at_value {
+        AtValue::Some(value) => {
+            node_to_element(el_ws)
+                .and_then(|element| {
+                    element
+                        .set_attribute(at.as_str(), value)
+                        .map_err(|_| "Problem setting an atrribute.")
+                })
+                .unwrap_or_else(crate::error);
+        }
+        AtValue::None => {
+            node_to_element(el_ws)
+                .and_then(|element| {
+                    element
+                        .set_attribute(at.as_str(), "")
+                        .map_err(|_| "Problem setting an atrribute.")
+                })
+                .unwrap_or_else(crate::error);
+        }
+        AtValue::Ignored => {
+            node_to_element(el_ws)
+                .and_then(|element| {
+                    element
+                        .remove_attribute(at.as_str())
+                        .map_err(|_| "Problem removing an atrribute.")
+                })
+                .unwrap_or_else(crate::error);
+        }
+    }
+}
+
 /// Create and return a `web_sys` Element from our virtual-dom `El`. The `web_sys`
 /// Element is a close analog to JS/DOM elements.
 ///
@@ -168,8 +102,8 @@ pub(crate) fn make_websys_el<Ms>(
             .expect("Problem creating web-sys element"),
     };
 
-    for (at, val) in &el_vdom.attrs.vals {
-        set_attr_shim(&el_ws, at, val);
+    for (at, attr_value) in &el_vdom.attrs.vals {
+        set_attr_value(&el_ws, at, attr_value);
     }
     if let Some(ns) = &el_vdom.namespace {
         el_ws
@@ -247,6 +181,18 @@ pub fn attach_el_and_children<Ms>(el_vdom: &mut El<Ms>, parent: &web_sys::Node) 
         }
     }
 
+    // @TODO handle also other Auto* attributes?
+    if let Some(at_value) = el_vdom.attrs.vals.get(&dom_types::At::AutoFocus) {
+        match at_value {
+            AtValue::Some(_) | AtValue::None => el_ws
+                .dyn_ref::<web_sys::HtmlElement>()
+                .expect("Problem casting Node as HtmlElement while focusing")
+                .focus()
+                .expect("Problem focusing to an element."),
+            AtValue::Ignored => (),
+        }
+    }
+
     // Perform side-effects specified for mounting.
     if let Some(mount_actions) = &mut el_vdom.hooks.did_mount {
         (mount_actions.actions)(el_ws);
@@ -278,15 +224,25 @@ pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_
                 Some(old_val) => {
                     // The value's different
                     if old_val != new_val {
-                        set_attr_shim(old_el_ws, key, new_val);
+                        set_attr_value(old_el_ws, key, new_val);
                     }
                 }
-                None => set_attr_shim(old_el_ws, key, new_val),
+                None => {
+                    set_attr_value(old_el_ws, key, new_val);
+                }
             }
+
             // We handle value in the vdom using attributes, but the DOM needs
             // to use set_value.
-            if key == &dom_types::At::Value {
-                crate::util::set_value(old_el_ws, new_val);
+            if let dom_types::At::Value = key {
+                match new_val {
+                    AtValue::Some(new_val) => {
+                        crate::util::set_value(old_el_ws, new_val);
+                    }
+                    AtValue::None | AtValue::Ignored => {
+                        crate::util::set_value(old_el_ws, "");
+                    }
+                }
             }
         }
         // Remove attributes that aren't in the new vdom.
@@ -358,7 +314,7 @@ pub fn to_mouse_event(event: &web_sys::Event) -> &web_sys::MouseEvent {
 /// and markdown strings. Includes children, recursively added.
 pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
     match node.node_type() {
-        1 => {
+        web_sys::Node::ELEMENT_NODE => {
             // Element node
             let node_ws = node
                 .dyn_ref::<web_sys::Element>()
@@ -380,7 +336,7 @@ pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
                         .as_string()
                         .expect("problem converting attr to string");
                     if let Some(attr_val) = node_ws.get_attribute(&attr_name2) {
-                        attrs.add(attr_name2.into(), attr_val);
+                        attrs.add(attr_name2.into(), &attr_val);
                     }
                 });
             el.attrs = attrs;
@@ -404,7 +360,7 @@ pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
             }
             Some(Node::Element(el))
         }
-        3 => Some(Node::Text(Text::new(
+        web_sys::Node::TEXT_NODE => Some(Node::Text(Text::new(
             node.text_content().expect("Can't find text"),
         ))),
         _ => {

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -233,16 +233,25 @@ pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_
             }
 
             // We handle value in the vdom using attributes, but the DOM needs
-            // to use set_value.
-            if let dom_types::At::Value = key {
-                match new_val {
+            // to use set_value or set_checked.
+            match key {
+                dom_types::At::Value => match new_val {
                     AtValue::Some(new_val) => {
                         crate::util::set_value(old_el_ws, new_val);
                     }
                     AtValue::None | AtValue::Ignored => {
                         crate::util::set_value(old_el_ws, "");
                     }
-                }
+                },
+                dom_types::At::Checked => match new_val {
+                    AtValue::Some(_) | AtValue::None => {
+                        crate::util::set_checked(old_el_ws, true).unwrap_or_else(crate::error);
+                    }
+                    AtValue::Ignored => {
+                        crate::util::set_checked(old_el_ws, false).unwrap_or_else(crate::error);
+                    }
+                },
+                _ => (),
             }
         }
         // Remove attributes that aren't in the new vdom.


### PR DESCRIPTION
https://github.com/David-OConnor/seed/issues/182

- First look at the file `src/dom_types/values.rs`.
    - It's the core of the new API with comments and examples.
- Then look at the a new example `examples/server_integration/client/src/example_e.rs`.
   - New API is tested here + I want to use it for testing issues with jumping cursor and closures.
- Then look at the `src/websys_bridge.rs` - find comment `// @TODO handle also other Auto* attributes?`.
   - I tried to fix issues with auto-focusing here.
   - You can try it with `cargo make start server_integration` - the first input should be focused.
- Breaking changes:
   - You need to call method `as_at_value` for `bool` attributes (e.g. `At::Disabled => false.as_at_value()`), otherwise it would render as `disabled="false"`.

Thanks for review!

P.S. Using `()` and `Option` as I suggested isn't possible, even with nightly specialization.