### PR TITLE
169 map message handlers closures

### DIFF
--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -17,7 +17,7 @@ pub mod values;
 
 pub trait MessageMapper<Ms, OtherMs> {
     type SelfWithOtherMs;
-    fn map_message(self, f: fn(Ms) -> OtherMs) -> Self::SelfWithOtherMs;
+    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Self::SelfWithOtherMs;
 }
 
 /// Common Namespaces
@@ -824,7 +824,7 @@ impl<Ms> Node<Ms> {
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
     type SelfWithOtherMs = Node<OtherMs>;
     /// See note on impl for El
-    fn map_message(self, f: fn(Ms) -> OtherMs) -> Node<OtherMs> {
+    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Node<OtherMs> {
         match self {
             Node::Element(el) => Node::Element(el.map_message(f)),
             Node::Text(text) => Node::Text(text),
@@ -835,8 +835,10 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
 
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<Node<Ms>> {
     type SelfWithOtherMs = Vec<Node<OtherMs>>;
-    fn map_message(self, f: fn(Ms) -> OtherMs) -> Vec<Node<OtherMs>> {
-        self.into_iter().map(|node| node.map_message(f)).collect()
+    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<Node<OtherMs>> {
+        self.into_iter()
+            .map(|node| node.map_message(f.clone()))
+            .collect()
     }
 }
 
@@ -889,15 +891,15 @@ impl<Ms> fmt::Debug for LifecycleHooks<Ms> {
 
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for LifecycleHooks<Ms> {
     type SelfWithOtherMs = LifecycleHooks<OtherMs>;
-    fn map_message(self, f: fn(Ms) -> OtherMs) -> Self::SelfWithOtherMs {
+    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Self::SelfWithOtherMs {
         LifecycleHooks {
             did_mount: self.did_mount.map(|d| DidMount {
                 actions: d.actions,
-                message: d.message.map(f),
+                message: d.message.map(f.clone()),
             }),
             did_update: self.did_update.map(|d| DidUpdate {
                 actions: d.actions,
-                message: d.message.map(f),
+                message: d.message.map(f.clone()),
             }),
             will_unmount: self.will_unmount.map(|d| WillUnmount {
                 actions: d.actions,
@@ -917,7 +919,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
     /// # Note
     /// There is an overhead to calling this versus keeping all messages under one type.
     /// The deeper the nested structure of children, the more time this will take to run.
-    fn map_message(self, f: fn(Ms) -> OtherMs) -> El<OtherMs> {
+    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> El<OtherMs> {
         El {
             tag: self.tag,
             attrs: self.attrs,
@@ -925,12 +927,12 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
             listeners: self
                 .listeners
                 .into_iter()
-                .map(|l| l.map_message(f))
+                .map(|l| l.map_message(f.clone()))
                 .collect(),
             children: self
                 .children
                 .into_iter()
-                .map(|c| c.map_message(f))
+                .map(|c| c.map_message(f.clone()))
                 .collect(),
             node_ws: self.node_ws,
             namespace: self.namespace,
@@ -941,8 +943,10 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
 
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<El<Ms>> {
     type SelfWithOtherMs = Vec<El<OtherMs>>;
-    fn map_message(self, f: fn(Ms) -> OtherMs) -> Vec<El<OtherMs>> {
-        self.into_iter().map(|el| el.map_message(f)).collect()
+    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<El<OtherMs>> {
+        self.into_iter()
+            .map(|el| el.map_message(f.clone()))
+            .collect()
     }
 }
 


### PR DESCRIPTION
https://github.com/David-OConnor/seed/issues/169

(It's based on PR https://github.com/David-OConnor/seed/pull/186 so code review makes sense after merge.)

Changes
- `MessageMapper`'s callback signature changed to `FnOnce`:
  - `fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone)`
- Fixed implementation of `MessageMapper` for `Listener`:
  - `message: None` => `message: self.message.map(f)`
- Event handlers in `events.rs` changed :
  - `handler: impl FnOnce(web_sys::KeyboardEvent) -> Ms + 'static + Clone`
- Updated example `server_integration\client\src\example_e.rs` - it uses closure in `raw_ev`.

Breaking changes
 - There shouldn't be any.

Notes
  - There are many new `.clone()` calls, but I think that the most of them should be cheap (i.e. compiler should optimize it - if it sees "closure" which actually doesn't closes anything it should mark it as function pointer `fn(..) -> ..` and because function pointer implements `Clone` and even `Copy`, I think that the `Clone/Copy` operation is cheap.
  - https://github.com/rust-lang/rfcs/blob/master/text/1558-closure-to-fn-coercion.md
