### PR TITLE
scalable application support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,6 @@ version = "0.1.0"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "seed 0.4.0",
- "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -132,7 +132,7 @@ command = "wasm-pack"
 args = ["test", "--firefox", "--", "--lib", "${@}"]
 
 [tasks.test_one_h]
-description = "Run a single test in headless Firefox. Ex 'cargo make test_one my_test'"
+description = "Run a single test in headless Firefox. Ex 'cargo make test_one_h my_test'"
 clear = true
 workspace = false
 install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V" }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ enum Msg {
 }
 
 /// How we update the model
-fn update(msg: Msg, model: &mut Model, _orders: &mut Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, _orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::Increment => model.count += 1,
         Msg::Decrement => model.count -= 1,
@@ -182,7 +182,7 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(|_,_| Model::default(), update, view)
         .finish()
         .run();
 }

--- a/examples/animation_frame/Cargo.toml
+++ b/examples/animation_frame/Cargo.toml
@@ -10,5 +10,4 @@ crate-type = ["cdylib"]
 [dependencies]
 seed = {path = "../../"}
 wasm-bindgen = "0.2.45"
-serde = "^1.0.92"
 rand = {version = "0.6.5", features = ["wasm-bindgen"]}

--- a/examples/animation_frame/index.html
+++ b/examples/animation_frame/index.html
@@ -22,8 +22,8 @@
   <section id="app"></section>
   <script type="module">
       // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-      import init from './pkg/package.js';
-      init('./pkg/package_bg.wasm');
+      import init from '/pkg/package.js';
+      init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -22,8 +22,8 @@
     <section id="app"></section>
     <script type="module">
       // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-      import init from './pkg/package.js';
-      init('./pkg/package_bg.wasm');
+      import init from '/pkg/package.js';
+      init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -34,7 +34,7 @@ enum Msg {
 }
 
 /// The sole source of updating the model
-fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::Increment => model.count += 1,
         Msg::Decrement => model.count -= 1,
@@ -105,7 +105,7 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(|_, _| Model::default(), update, view)
         .finish()
         .run();
 }

--- a/examples/mathjax/index.html
+++ b/examples/mathjax/index.html
@@ -29,8 +29,8 @@
         <section id="app"></section>
         <script type="module">
             // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-            import init from './pkg/package.js';
-            init('./pkg/package_bg.wasm');
+            import init from '/pkg/package.js';
+            init('/pkg/package_bg.wasm');
         </script>
     </body>
 </html>

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -182,9 +182,13 @@ e^{-\mathbf{A}} = \mathbf{B} + [\mathbf{A}, \mathbf{B}]"
     ]
 }
 
+// Init
+
+fn init(_: Url, _: &mut impl Orders<Msg>) -> Model {
+    Model::default()
+}
+
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(Model::default(), |_, _, _| (), view)
-        .finish()
-        .run();
+    seed::App::build(init, |_, _, _| (), view).finish().run();
 }

--- a/examples/orders/index.html
+++ b/examples/orders/index.html
@@ -22,8 +22,8 @@
     <section id="app"></section>
     <script type="module">
         // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-        import init from './pkg/package.js';
-        init('./pkg/package_bg.wasm');
+        import init from '/pkg/package.js';
+        init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -28,7 +28,7 @@ enum Msg {
     TimeoutError,
 }
 
-fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::Greet => {
             model.greet_clicked = true;
@@ -94,7 +94,7 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(|_, _| Model::default(), update, view)
         .finish()
         .run();
 }

--- a/examples/server_integration/client/index.html
+++ b/examples/server_integration/client/index.html
@@ -15,8 +15,8 @@
     <section id="app"></section>
     <script type="module">
         // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-        import init from './pkg/package.js';
-        init('./pkg/package_bg.wasm');
+        import init from '/pkg/package.js';
+        init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/server_integration/client/src/example_a.rs
+++ b/examples/server_integration/client/src/example_a.rs
@@ -1,6 +1,7 @@
 use futures::Future;
 use seed::fetch;
 use seed::prelude::*;
+use std::borrow::Cow;
 
 use shared;
 
@@ -9,8 +10,8 @@ pub const DESCRIPTION: &str = "Write something into input and click on 'Send mes
     Message will be send to server and then it wil be returned with ordinal number.
     Ordinal number is incremented by server with each request.";
 
-fn get_request_url() -> String {
-    "/api/send-message".into()
+fn get_request_url() -> impl Into<Cow<'static, str>> {
+    "/api/send-message"
 }
 
 // Model
@@ -30,7 +31,7 @@ pub enum Msg {
     Fetched(fetch::ResponseDataResult<shared::SendMessageResponseBody>),
 }
 
-pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::NewMessageChanged(message) => {
             model.new_message = message;

--- a/examples/server_integration/client/src/example_b.rs
+++ b/examples/server_integration/client/src/example_b.rs
@@ -2,14 +2,15 @@ use futures::Future;
 use seed::fetch;
 use seed::prelude::*;
 use serde::Deserialize;
+use std::borrow::Cow;
 
 pub const TITLE: &str = "Example B";
 pub const DESCRIPTION: &str =
     "Click button 'Try to Fetch JSON' to send request to non-existent endpoint.
     Server will return 404 with empty body and Serde then fail to decode body into predefined JSON.";
 
-fn get_request_url() -> String {
-    "/api/non-existent-endpoint".into()
+fn get_request_url() -> impl Into<Cow<'static, str>> {
+    "/api/non-existent-endpoint"
 }
 
 // Model
@@ -32,7 +33,7 @@ pub enum Msg {
     Fetched(fetch::FetchResult<ExpectedResponseData>),
 }
 
-pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::SendRequest => {
             orders.skip().perform_cmd(send_request());

--- a/examples/server_integration/client/src/example_c.rs
+++ b/examples/server_integration/client/src/example_c.rs
@@ -1,13 +1,14 @@
 use futures::Future;
 use seed::fetch;
 use seed::prelude::*;
+use std::borrow::Cow;
 
 pub const TITLE: &str = "Example C";
 pub const DESCRIPTION: &str =
     "Click button 'Send request` to send request to endpoint with configurable delay.
     Click again to abort request.";
 
-fn get_request_url() -> String {
+fn get_request_url() -> impl Into<Cow<'static, str>> {
     let response_delay_ms: u32 = 2000;
     format!("/api/delayed-response/{}", response_delay_ms)
 }
@@ -42,7 +43,7 @@ pub enum Msg {
     Fetched(fetch::ResponseDataResult<String>),
 }
 
-pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::SendRequest => {
             model.status = Status::WaitingForResponse;
@@ -106,8 +107,8 @@ fn view_response_data_result(
     }
 }
 
-fn view_fail_reason(fail_reason: &fetch::FailReason) -> Node<Msg> {
-    if let fetch::FailReason::RequestError(fetch::RequestError::DomException(dom_exception)) =
+fn view_fail_reason(fail_reason: &fetch::FailReason<String>) -> Node<Msg> {
+    if let fetch::FailReason::RequestError(fetch::RequestError::DomException(dom_exception), _) =
         fail_reason
     {
         if dom_exception.name() == "AbortError" {

--- a/examples/server_integration/client/src/example_d.rs
+++ b/examples/server_integration/client/src/example_d.rs
@@ -1,6 +1,7 @@
 use futures::Future;
 use seed::fetch;
 use seed::prelude::*;
+use std::borrow::Cow;
 
 pub const TITLE: &str = "Example D";
 pub const DESCRIPTION: &str =
@@ -9,7 +10,7 @@ pub const DESCRIPTION: &str =
 
 const TIMEOUT: u32 = 2000;
 
-fn get_request_url() -> String {
+fn get_request_url() -> impl Into<Cow<'static, str>> {
     let response_delay_ms: u32 = 2500;
     format!("/api/delayed-response/{}", response_delay_ms)
 }
@@ -48,7 +49,7 @@ pub enum Msg {
     Fetched(fetch::FetchObject<()>),
 }
 
-pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::SendRequest => {
             model.status = Status::WaitingForResponse(TimeoutStatus::Enabled);
@@ -102,8 +103,8 @@ pub fn view(model: &Model) -> impl View<Msg> {
     }
 }
 
-fn view_fail_reason(fail_reason: &fetch::FailReason, status: &Status) -> Vec<Node<Msg>> {
-    if let fetch::FailReason::RequestError(fetch::RequestError::DomException(dom_exception)) =
+fn view_fail_reason(fail_reason: &fetch::FailReason<()>, status: &Status) -> Vec<Node<Msg>> {
+    if let fetch::FailReason::RequestError(fetch::RequestError::DomException(dom_exception), _) =
         fail_reason
     {
         if dom_exception.name() == "AbortError" {

--- a/examples/server_integration/client/src/example_e.rs
+++ b/examples/server_integration/client/src/example_e.rs
@@ -1,6 +1,7 @@
 use futures::Future;
 use seed::fetch;
 use seed::prelude::*;
+use std::borrow::Cow;
 use std::mem;
 use wasm_bindgen::JsCast;
 use web_sys::{
@@ -13,8 +14,8 @@ pub const TITLE: &str = "Example E";
 pub const DESCRIPTION: &str =
     "Fill form and click 'Submit` button. Server echoes the form back. See console log for more info.";
 
-fn get_request_url() -> String {
-    "/api/form".into()
+fn get_request_url() -> impl Into<Cow<'static, str>> {
+    "/api/form"
 }
 
 // Model
@@ -81,7 +82,7 @@ pub enum Msg {
     ServerResponded(fetch::ResponseDataResult<String>),
 }
 
-pub fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::TitleChanged(title) => model.form_mut().title = title,
         Msg::DescriptionChanged(description) => model.form_mut().description = description,

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -33,27 +33,22 @@ enum Msg {
     ExampleE(example_e::Msg),
 }
 
-fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::ExampleA(msg) => {
-            *orders = call_update(example_a::update, msg, &mut model.example_a)
-                .map_message(Msg::ExampleA);
+            example_a::update(msg, &mut model.example_a, &mut orders.proxy(Msg::ExampleA));
         }
         Msg::ExampleB(msg) => {
-            *orders = call_update(example_b::update, msg, &mut model.example_b)
-                .map_message(Msg::ExampleB);
+            example_b::update(msg, &mut model.example_b, &mut orders.proxy(Msg::ExampleB));
         }
         Msg::ExampleC(msg) => {
-            *orders = call_update(example_c::update, msg, &mut model.example_c)
-                .map_message(Msg::ExampleC);
+            example_c::update(msg, &mut model.example_c, &mut orders.proxy(Msg::ExampleC));
         }
         Msg::ExampleD(msg) => {
-            *orders = call_update(example_d::update, msg, &mut model.example_d)
-                .map_message(Msg::ExampleD);
+            example_d::update(msg, &mut model.example_d, &mut orders.proxy(Msg::ExampleD));
         }
         Msg::ExampleE(msg) => {
-            *orders = call_update(example_e::update, msg, &mut model.example_e)
-                .map_message(Msg::ExampleE);
+            example_e::update(msg, &mut model.example_e, &mut orders.proxy(Msg::ExampleE));
         }
     }
 }
@@ -112,7 +107,7 @@ fn view_example_introduction(title: &str, description: &str) -> Vec<Node<Msg>> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(|_, _| Model::default(), update, view)
         .finish()
         .run();
 }

--- a/examples/server_integration/server/src/main.rs
+++ b/examples/server_integration/server/src/main.rs
@@ -89,7 +89,8 @@ fn main() -> std::io::Result<()> {
                 web::scope("/api/")
                     .service(send_message)
                     .service(delayed_response)
-                    .service(form),
+                    .service(form)
+                    .default_service(web::route().to(web::HttpResponse::NotFound)),
             )
             .service(Files::new("/public", "./client/public"))
             .service(Files::new("/pkg", "./client/pkg"))

--- a/examples/server_interaction/index.html
+++ b/examples/server_interaction/index.html
@@ -22,8 +22,8 @@
     <section id="app"></section>
     <script type="module">
       // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-      import init from './pkg/package.js';
-      init('./pkg/package_bg.wasm');
+      import init from '/pkg/package.js';
+      init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -21,8 +21,8 @@
 
     <script type="module">
       // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-      import init from './pkg/package.js';
-      init('./pkg/package_bg.wasm');
+      import init from '/pkg/package.js';
+      init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -132,7 +132,7 @@ fn edit_submit(posit: usize, model: &mut Model) {
     }
 }
 
-fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     model.sync_storage(); // Doing it here will miss the most recent update...
 
     // todo has some bugs.
@@ -361,7 +361,7 @@ fn routes(url: seed::Url) -> Msg {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(|_, _| Model::default(), update, view)
         .routes(routes)
         .finish()
         .run();

--- a/examples/update_from_js/index.html
+++ b/examples/update_from_js/index.html
@@ -24,8 +24,8 @@
     <section id="app"></section>
     <script type="module">
       // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-      import init from './pkg/package.js';
-      init('./pkg/package_bg.wasm');
+      import init from '/pkg/package.js';
+      init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -27,7 +27,7 @@ enum Msg {
     Tick(String),
 }
 
-fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::ClockEnabled => log!("Clock enabled"),
         Msg::Tick(time) => model.time_from_js = Some(time),
@@ -50,7 +50,7 @@ fn view(model: &Model) -> Node<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(|_,_| Model::default(), update, view)
         // `trigger_update_handler` processes JS event
         // and forwards it to `update` function.
         .window_events(|_| vec![trigger_update_handler()])

--- a/examples/websocket/index.html
+++ b/examples/websocket/index.html
@@ -15,8 +15,8 @@
     <section id="app"></section>
     <script type="module">
       // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-      import init from './pkg/package.js';
-      init('./pkg/package_bg.wasm');
+      import init from '/pkg/package.js';
+      init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/websocket/src/server.rs
+++ b/examples/websocket/src/server.rs
@@ -8,17 +8,6 @@ struct Server {
 }
 
 impl Handler for Server {
-    fn on_request(&mut self, req: &Request) -> Result<(Response)> {
-        match req.resource() {
-            "/ws" => Response::from_request(req),
-            _ => Ok(Response::new(
-                200,
-                "OK",
-                b"Websocket server is running".to_vec(),
-            )),
-        }
-    }
-
     // Handle messages recieved in the websocket (in this case, only on /ws)
     fn on_message(&mut self, msg: Message) -> Result<()> {
         let client_id: usize = self.out.token().into();
@@ -39,6 +28,17 @@ impl Handler for Server {
         .into();
         // Broadcast to all connections
         self.out.broadcast(server_msg)
+    }
+
+    fn on_request(&mut self, req: &Request) -> Result<(Response)> {
+        match req.resource() {
+            "/ws" => Response::from_request(req),
+            _ => Ok(Response::new(
+                200,
+                "OK",
+                b"Websocket server is running".to_vec(),
+            )),
+        }
     }
 }
 

--- a/examples/window_events/index.html
+++ b/examples/window_events/index.html
@@ -22,8 +22,8 @@
     <section id="app"></section>
     <script type="module">
       // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
-      import init from './pkg/package.js';
-      init('./pkg/package_bg.wasm');
+      import init from '/pkg/package.js';
+      init('/pkg/package_bg.wasm');
     </script>
   </body>
 </html>

--- a/examples/window_events/src/lib.rs
+++ b/examples/window_events/src/lib.rs
@@ -28,7 +28,7 @@ enum Msg {
     KeyPressed(web_sys::KeyboardEvent),
 }
 
-fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::ToggleWatching => model.watching = !model.watching,
         Msg::UpdateCoords(ev) => model.coords = (ev.screen_x(), ev.screen_y()),
@@ -83,7 +83,7 @@ fn window_events(model: &Model) -> Vec<Listener<Msg>> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(Model::default(), update, view)
+    seed::App::build(|_, _| Model::default(), update, view)
         .window_events(window_events)
         .finish()
         .run();

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -1174,7 +1174,7 @@ pub mod tests {
     struct Model {}
 
     fn create_app() -> seed::App<Msg, Model, Node<Msg>> {
-        seed::App::build(Model {}, |_, _, _| (), |_| div![])
+        seed::App::build(|_,_| Model {}, |_, _, _| (), |_| seed::empty())
             // mount to the element that exists even in the default test html
             .mount(util::body())
             .finish()

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,7 +1,10 @@
 //! This module contains code related to event handling; ie things that update the dom, related to
 //! `web_sys::Event`
 
-use crate::{dom_types::MessageMapper, util};
+use crate::{
+    dom_types::MessageMapper,
+    util::{self, ClosureNew},
+};
 
 use enclose::enclose;
 use serde::de::DeserializeOwned;
@@ -222,10 +225,10 @@ impl<Ms> Listener<Ms> {
     {
         let mut handler = self.handler.take().expect("Can't find old handler");
         // This is the closure ran when a DOM element has an user defined callback
-        let closure = Closure::wrap(Box::new(move |event: web_sys::Event| {
+        let closure = Closure::new(move |event: web_sys::Event| {
             let msg = handler(event);
             mailbox.send(msg);
-        }) as Box<dyn FnMut(web_sys::Event) + 'static>);
+        });
 
         (el_ws.as_ref() as &web_sys::EventTarget)
             .add_event_listener_with_callback(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod dom_types;
 pub mod events;
 pub mod fetch;
 mod next_tick;
+pub mod orders;
 mod patch;
 pub mod routing;
 pub mod storage;
@@ -35,6 +36,8 @@ pub mod gloo_timers;
 pub const fn empty<Ms>() -> dom_types::Node<Ms> {
     dom_types::Node::Empty
 }
+
+// @TODO remove `set_interval` and `set_timeout`? Alternative from `gloo` should be used instead.
 
 /// A high-level wrapper for `web_sys::window.set_interval_with_callback_and_timeout_and_arguments_0`:
 ///
@@ -84,11 +87,15 @@ pub mod prelude {
             input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev, trigger_update_handler,
             Ev,
         },
+        orders::Orders,
+        routing::Url,
         // macros are exported in crate root
         // https://github.com/rust-lang-nursery/reference/blob/master/src/macros-by-example.md
         shortcuts::*,
-        util::{request_animation_frame, RequestAnimationFrameHandle, RequestAnimationFrameTime},
-        vdom::{call_update, Orders},
+        util::{
+            request_animation_frame, ClosureNew, RequestAnimationFrameHandle,
+            RequestAnimationFrameTime,
+        },
     };
     pub use indexmap::IndexMap; // for attrs and style to work.
     pub use wasm_bindgen::prelude::*;
@@ -111,7 +118,7 @@ pub mod tests {
         use crate::{
             dom_types::{El, UpdateEl},
             events::mouse_ev,
-            vdom::Orders,
+            orders::Orders,
         };
 
         struct Model {
@@ -129,7 +136,7 @@ pub mod tests {
             Increment,
         }
 
-        fn update(msg: Msg, model: &mut Model, _: &mut Orders<Msg>) {
+        fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
             match msg {
                 Msg::Increment => model.val += 1,
             }
@@ -149,7 +156,7 @@ pub mod tests {
 
         #[wasm_bindgen]
         pub fn render() {
-            seed::App::build(Model::default(), update, view)
+            seed::App::build(|_, _| Model::default(), update, view)
                 .mount("body")
                 .routes(routes)
                 .window_events(window_events)

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -1,0 +1,266 @@
+use crate::dom_types::{MessageMapper, View};
+use crate::vdom::{App, Effect, ShouldRender};
+use futures::Future;
+use std::{collections::VecDeque, convert::identity, rc::Rc};
+
+// ------ Orders ------
+
+pub trait Orders<Ms: 'static, GMs = ()> {
+    type AppMs: 'static;
+    type Mdl: 'static;
+    type ElC: View<Self::AppMs> + 'static;
+
+    /// Automatically map message type. It allows you to pass `Orders` into child module.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    ///Msg::Child(child_msg) => {
+    ///    child::update(child_msg, &mut model.child, &mut orders.proxy(Msg::Child));
+    ///}
+    /// ```
+    fn proxy<ChildMs: 'static>(
+        &mut self,
+        f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
+    ) -> OrdersProxy<ChildMs, Self::AppMs, Self::Mdl, Self::ElC, GMs>;
+
+    /// Schedule web page rerender after model update. It's the default behaviour.
+    fn render(&mut self) -> &mut Self;
+
+    /// Force web page to rerender immediately after model update.
+    fn force_render_now(&mut self) -> &mut Self;
+
+    /// Don't rerender web page after model update.
+    fn skip(&mut self) -> &mut Self;
+
+    /// Call function `update` with the given `msg` after model update.
+    /// You can call this function more times - messages will be sent in the same order.
+    fn send_msg(&mut self, msg: Ms) -> &mut Self;
+
+    /// Schedule given future `cmd` to be executed after model update.
+    /// Result is send to function `update`.
+    /// You can call this function more times - futures will be scheduled in the same order.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    ///fn write_emoticon_after_delay() -> impl Future<Item=Msg, Error=Msg> {
+    ///    TimeoutFuture::new(2_000)
+    ///        .map(|_| Msg::WriteEmoticon)
+    ///        .map_err(|_| Msg::TimeoutError)
+    ///}
+    ///orders.perform_cmd(write_emoticon_after_delay());
+    /// ```
+    fn perform_cmd<C>(&mut self, cmd: C) -> &mut Self
+    where
+        C: Future<Item = Ms, Error = Ms> + 'static;
+
+    /// Similar to `send_msg`, but calls function `sink` with the given global message.
+    fn send_g_msg(&mut self, g_msg: GMs) -> &mut Self;
+
+    /// Similar to `perform_cmd`, but result is send to function `sink`.
+    fn perform_g_cmd<C>(&mut self, g_cmd: C) -> &mut Self
+    where
+        C: Future<Item = GMs, Error = GMs> + 'static;
+
+    /// Get app instance. Cloning is cheap because `App` contains only `Rc` fields.
+    fn clone_app(&self) -> App<Self::AppMs, Self::Mdl, Self::ElC, GMs>;
+
+    /// Get function which maps module's `Msg` to app's (root's) one.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    ///let (app, msg_mapper) = (orders.clone_app(), orders.msg_mapper());
+    ///app.update(msg_mapper(Msg::AMessage));
+    /// ```
+    fn msg_mapper(&self) -> Box<dyn Fn(Ms) -> Self::AppMs>;
+}
+
+// ------ OrdersContainer ------
+
+#[allow(clippy::module_name_repetitions)]
+pub struct OrdersContainer<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs = ()> {
+    pub(crate) should_render: ShouldRender,
+    pub(crate) effects: VecDeque<Effect<Ms, GMs>>,
+    app: App<Ms, Mdl, ElC, GMs>,
+}
+
+impl<Ms, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
+    pub fn new(app: App<Ms, Mdl, ElC, GMs>) -> Self {
+        Self {
+            should_render: ShouldRender::Render,
+            effects: VecDeque::new(),
+            app,
+        }
+    }
+}
+
+impl<Ms: 'static, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
+    for OrdersContainer<Ms, Mdl, ElC, GMs>
+{
+    type AppMs = Ms;
+    type Mdl = Mdl;
+    type ElC = ElC;
+
+    #[allow(clippy::redundant_closure)]
+    fn proxy<ChildMs: 'static>(
+        &mut self,
+        f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
+    ) -> OrdersProxy<ChildMs, Ms, Mdl, ElC, GMs> {
+        OrdersProxy::new(self, move |child_ms| f.clone()(child_ms))
+    }
+
+    fn render(&mut self) -> &mut Self {
+        self.should_render = ShouldRender::Render;
+        self
+    }
+
+    fn force_render_now(&mut self) -> &mut Self {
+        self.should_render = ShouldRender::ForceRenderNow;
+        self
+    }
+
+    fn skip(&mut self) -> &mut Self {
+        self.should_render = ShouldRender::Skip;
+        self
+    }
+
+    fn send_msg(&mut self, msg: Ms) -> &mut Self {
+        self.effects.push_back(msg.into());
+        self
+    }
+
+    fn perform_cmd<C>(&mut self, cmd: C) -> &mut Self
+    where
+        C: Future<Item = Ms, Error = Ms> + 'static,
+    {
+        let effect = Effect::Cmd(Box::new(cmd));
+        self.effects.push_back(effect);
+        self
+    }
+
+    fn send_g_msg(&mut self, g_msg: GMs) -> &mut Self {
+        let effect = Effect::GMsg(g_msg);
+        self.effects.push_back(effect);
+        self
+    }
+
+    fn perform_g_cmd<C>(&mut self, g_cmd: C) -> &mut Self
+    where
+        C: Future<Item = GMs, Error = GMs> + 'static,
+    {
+        let effect = Effect::GCmd(Box::new(g_cmd));
+        self.effects.push_back(effect);
+        self
+    }
+
+    fn clone_app(&self) -> App<Self::AppMs, Self::Mdl, Self::ElC, GMs> {
+        self.app.clone()
+    }
+
+    fn msg_mapper(&self) -> Box<dyn Fn(Ms) -> Self::AppMs> {
+        Box::new(identity)
+    }
+}
+
+// ------ OrdersProxy ------
+
+#[allow(clippy::module_name_repetitions)]
+pub struct OrdersProxy<'a, Ms, AppMs: 'static, Mdl: 'static, ElC: View<AppMs>, GMs: 'static = ()> {
+    orders_container: &'a mut OrdersContainer<AppMs, Mdl, ElC, GMs>,
+    f: Rc<dyn Fn(Ms) -> AppMs>,
+}
+
+impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs>, GMs>
+    OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
+{
+    pub fn new(
+        orders_container: &'a mut OrdersContainer<AppMs, Mdl, ElC, GMs>,
+        f: impl Fn(Ms) -> AppMs + 'static,
+    ) -> Self {
+        OrdersProxy {
+            orders_container,
+            f: Rc::new(f),
+        }
+    }
+}
+
+impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs> + 'static, GMs> Orders<Ms, GMs>
+    for OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
+{
+    type AppMs = AppMs;
+    type Mdl = Mdl;
+    type ElC = ElC;
+
+    fn proxy<ChildMs: 'static>(
+        &mut self,
+        f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
+    ) -> OrdersProxy<ChildMs, AppMs, Mdl, ElC, GMs> {
+        let previous_f = self.f.clone();
+        OrdersProxy {
+            orders_container: self.orders_container,
+            f: Rc::new(move |child_ms| previous_f(f.clone()(child_ms))),
+        }
+    }
+
+    fn render(&mut self) -> &mut Self {
+        self.orders_container.render();
+        self
+    }
+
+    fn force_render_now(&mut self) -> &mut Self {
+        self.orders_container.force_render_now();
+        self
+    }
+
+    fn skip(&mut self) -> &mut Self {
+        self.orders_container.skip();
+        self
+    }
+
+    #[allow(clippy::redundant_closure)]
+    fn send_msg(&mut self, msg: Ms) -> &mut Self {
+        let f = self.f.clone();
+        self.orders_container
+            .effects
+            .push_back(Effect::Msg(msg).map_message(move |ms| f(ms)));
+        self
+    }
+
+    #[allow(clippy::redundant_closure)]
+    fn perform_cmd<C>(&mut self, cmd: C) -> &mut Self
+    where
+        C: Future<Item = Ms, Error = Ms> + 'static,
+    {
+        let f = self.f.clone();
+        let effect = Effect::Cmd(Box::new(cmd)).map_message(move |ms| f(ms));
+        self.orders_container.effects.push_back(effect);
+        self
+    }
+
+    fn send_g_msg(&mut self, g_msg: GMs) -> &mut Self {
+        let effect = Effect::GMsg(g_msg);
+        self.orders_container.effects.push_back(effect);
+        self
+    }
+
+    fn perform_g_cmd<C>(&mut self, g_cmd: C) -> &mut Self
+    where
+        C: Future<Item = GMs, Error = GMs> + 'static,
+    {
+        let effect = Effect::GCmd(Box::new(g_cmd));
+        self.orders_container.effects.push_back(effect);
+        self
+    }
+
+    fn clone_app(&self) -> App<Self::AppMs, Self::Mdl, Self::ElC, GMs> {
+        self.orders_container.clone_app()
+    }
+
+    #[allow(clippy::redundant_closure)]
+    fn msg_mapper(&self) -> Box<dyn Fn(Ms) -> Self::AppMs> {
+        let f = self.f.clone();
+        Box::new(move |ms| f(ms))
+    }
+}

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -111,13 +111,13 @@ where
     }
 }
 
-fn patch_el<'a, Ms, Mdl, ElC: View<Ms>>(
+fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     mut old: El<Ms>,
     new: &'a mut El<Ms>,
     parent: &web_sys::Node,
     mailbox: &Mailbox<Ms>,
-    app: &App<Ms, Mdl, ElC>,
+    app: &App<Ms, Mdl, ElC, GMs>,
 ) -> Option<&'a web_sys::Node> {
     if old != *new {
         // At this step, we already assume we have the right element - either
@@ -280,14 +280,14 @@ fn add_el_helper<Ms>(
 
 /// Routes patching through different channels, depending on the Node variant
 /// of old and new.
-pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>>(
+pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     old: Node<Ms>,
     new: &'a mut Node<Ms>,
     parent: &web_sys::Node,
     next_node: Option<web_sys::Node>,
     mailbox: &Mailbox<Ms>,
-    app: &App<Ms, Mdl, ElC>,
+    app: &App<Ms, Mdl, ElC, GMs>,
 ) -> Option<&'a web_sys::Node> {
     // Old_el_ws is what we're patching, with items from the new vDOM el; or replacing.
     // We go through each combination of new and old variants to determine how to patch.

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -164,8 +164,7 @@ macro_rules! raw {
 #[macro_export]
 macro_rules! md {
     ($md:expr) => {
-        let el = El::from_markdown($md)
-        $crate::dom_types::Node::Element(el)
+        El::from_markdown($md)
     };
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -68,7 +68,7 @@ pub fn get_value(target: &web_sys::EventTarget) -> Result<String, &'static str> 
         };
         ($element:ty, $result_callback:expr) => {
             if let Some(input) = target.dyn_ref::<$element>() {
-                return ($result_callback(input)).map(|_| input.value().to_string());
+                return $result_callback(input).map(|_| input.value().to_string());
             }
         };
     }
@@ -106,7 +106,7 @@ pub fn set_value(target: &web_sys::EventTarget, value: &str) -> Result<(), &'sta
         };
         ($element:ty, $value_result_callback:expr) => {
             if let Some(input) = target.dyn_ref::<$element>() {
-                return ($value_result_callback(input)).map(|value| input.set_value(value));
+                return $value_result_callback(input).map(|value| input.set_value(value));
             }
         };
     }
@@ -173,8 +173,7 @@ pub fn set_checked(target: &web_sys::EventTarget, value: bool) -> Result<(), &'s
     Err("Only `HtmlInputElement` and `HtmlMenuItemElement` can be used in function `set_checked`.")
 }
 
-// @TODO: (1) Replace `Closure::wrap` in codebase with `Closure::new` (inspiration in `routing.rs`)
-// @TODO: (2) Delete once `Closure::new` is stable
+// @TODO: Delete once `Closure::new` is stable
 // https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html
 /// Prevent repetition when wrapping closures.
 pub trait ClosureNew<T> {


### PR DESCRIPTION
Well, [RealWorld example](https://github.com/MartinKavik/seed-rs-realworld) is almost done (code is complete, I need to update readme, create demo and write some tests). So I can finally create PR with improvements which I created while I was working on it. 
There are relatively many changes so I'll try to explain them on examples.

---

Let's look at `examples/animation_frame/src/lib.rs`:

 **1. Change:**
From:
```rust
fn update(msg: Msg, model: &mut Model, orders: &mut Orders<Msg>) {
```
To:
```rust
fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
```
`Order` isn't `struct` but `trait` now, so we have to use keyword `impl`. It's a breaking change but it has advantages which I'll describe later.

**2. Change**
From:
```rust
let cb = Closure::wrap(Box::new(|time| {
    seed::update(Msg::OnAnimationFrame(time));
}) as Box<FnMut(RequestAnimationFrameTime)>);
```
To:
```rust
let (app, msg_mapper) = (orders.clone_app(), orders.msg_mapper());
let cb = Closure::new(move |time| {
    app.update(msg_mapper(Msg::OnAnimationFrame(time)));
});
```
`orders` has a new methods -`clone_app` and `msg_mapper`. They allow us to send app instance into closures without magic like `seed::update` or passing it somehow through `Model` (it was relatively often requested feature). It's possible thanks to `impl Orders` because it "hides"  `App` type parameters. So we don't need to derive `Serialize` & `Deserialize` and register `trigger_update_handler` anymore. Note: I also changed `Closure::wrap` to `Closure::new` where possible in the whole codebase. 

**3. Change**
From:
```rust
enum Msg {
    Init,
...
match msg {
        Msg::Init => {
            orders
                .send_msg(Msg::SetViewportWidth)
                .send_msg(Msg::NextAnimationStep)
                .skip();
        }
...
app.update(Msg::Init);
```
To:
```rust
fn init(_: Url, orders: &mut impl Orders<Msg>) -> Model {
    orders
        .send_msg(Msg::SetViewportWidth)
        .send_msg(Msg::NextAnimationStep);
    Model::default()
}
pub fn render() {
    seed::App::build(init, update, view)
```
This change removes the need to call `app.update` and create special handling with `Msg::Init`. It also allows us to choose the right `Model` according to `Url`  so we don't have to create a special default `Model` for the case _"I don't know which page to display yet"_. It's the second breaking change.

---

Let's look at `examples/server_integration/client/src/lib.rs`:

 **4. Change:**
From:
```rust
Msg::ExampleA(msg) => {
    *orders = call_update(example_a::update, msg, &mut model.example_a)
    .map_message(Msg::ExampleA);
}
```
To:
```rust
Msg::ExampleA(msg) => {
    example_a::update(msg, &mut model.example_a, &mut orders.proxy(Msg::ExampleA));
}
```
There is another new method in `orders`: `proxy`. It removes boilerplate for plumbing sub-modules and allows us to pass `orders` instead of creating new ones. So we can pass `app` instance and `effect` queue through modules. Note: I've removed helper function `call_update` - it's the third breaking change.

---

Let's look at `src/routing.rs`:

**5. Change**
From:
```rust
// The first character being / indicates a rel link, which is what
// we're intercepting.
// todo: Handle other cases that imply a relative link.
// todo: I think not having anything, eg no http/www implies
// todo rel link as well.
```
To:
```rust
// The first character being / or empty href indicates a rel link, which is what
// we're intercepting.
// @TODO: Resolve it properly, see Elm implementation:
// @TODO: https://github.com/elm/browser/blob/9f52d88b424dd12cab391195d5b090dd4639c3b0/src/Elm/Kernel/Browser.js#L157
...
// @TODO should be empty href ignored?
if !href.is_empty() {
    // Route internally based on href's value
    let url = push_route(Url::from(href));
   update(routes(url));
}
```
The main goal is to don't refresh browser tab on click the element with empty link (i.e. click on `<a href=""></a>` does nothing.).

---

Let's look at `src/fetch.rs`:

**6. Change**
From:
```rust
pub fn new(url: String) -> Self { 
...
pub enum FailReason { 
    RequestError(RequestError),
    Status(Status),
    DataError(DataError),
}
...
SerdeError(Rc<serde_json::Error>), 
...
 T: DeserializeOwned + Debug + 'static
```

To:
```rust
pub fn new(url: impl Into<Cow<'static, str>>) -> Self {     // <--- A
...
// @TODO use https://github.com/rust-lang-nursery/failure?
pub enum FailReason<T> {
    RequestError(RequestError, FetchObject<T>),   // <--- B
    Status(Status, FetchObject<T>),
    DataError(DataError, FetchObject<T>),
}
...
type Json = String;
SerdeError(Rc<serde_json::Error>, Json),    // <--- C
...
T: DeserializeOwned + 'static,          // <--- D
```
A - more ergonomic API - you can pass `url` as a `String` or `&'static str`
B - if request fails, you want to know why and get more information or e.g. try another deserializer
C - if deserialization fails, you can try it again with another deserializer
D - more ergonomic API - `Debug` was needed because of ugly code, fixed

Motivation for B+C: 
Example - Server sends either status 200 + expected data (like list of blog articles) or 4xx and list of errors. => So we try to parse response data into articles if the status code is 200 or try to parse errors if code is 400 or at least log problems. It's more comfortable with those changes.

4th breaking change.

---

Let's look at the RealWorld example, because I haven't written example yet. [Realworld's lib.rs](https://github.com/MartinKavik/seed-rs-realworld/blob/master/src/lib.rs):

**7. Change**
From:
```rust
// Nothing - it's a new feature.
```
To:
```rust
#[wasm_bindgen(start)]
pub fn start() {
    seed::App::build(init, update, view)
        .routes(|url| Msg::RouteChanged(url.try_into().ok()))
        .sink(sink)      //  <------- new method
        .finish()
        .run();
}

pub enum GMsg {
    RoutePushed(Route<'static>),
    SessionChanged(Session),
}

fn sink<'a>(g_msg: GMsg, model: &mut Model<'a>, orders: &mut impl Orders<Msg<'static>, GMsg>) {
    if let GMsg::RoutePushed(ref route) = g_msg {
        orders.send_msg(Msg::RouteChanged(Some(route.clone())));
    }
   // or classic `match g_msg` like in `Update` function
   ... 

// File: ` seed-rs-realworld/src/route.rs `:
pub fn go_to<Ms: 'static>(route: Route<'static>, orders: &mut impl Orders<Ms, GMsg>) {
    seed::push_route(route.clone());
    orders.send_g_msg(GMsg::RoutePushed(route));
}
```
It's a new concept for communication among modules. `sink` it's almost the same like `update` but you received `GMsg` ("global message") instead of module's `Msg`. I'm using it in RealWorld example to notify root module that we want to change page/url (de facto `child -> parent` communication) or for sending session data into pages (`event producer -> event sinks`).
How to use it:
  - create enum `GMsg`
  - associate it with `Orders` in `update`, `init` and `sink` functions (just add 2nd parameter):
      - `&mut impl Orders<Msg, GMsg>`  (Note: Default global message is `()`)
  - send messages and perform commands with new `Orders` methods:
      - `orders.send_g_msg(GMsg::Something)` or `orders.perform_g_cmd(...)`
  - or you can use `app` instance: `app.sink(GMsg::Foo)`.

---

**Smaller changes:**
- Fixed macro `md`.
- Changed `Closure::wrap` to `Closure::new` except 2 cases in `lib.rs`: `set_interval` and `set_timeout` (Added `todo` that we should remove them because we are using `gloo`).
- Added `dyn` everywhere (probably same as PR https://github.com/David-OConnor/seed/pull/188).
- Fixed paths in all examples (see for example `examples/animation_frame/index.html`. (They was failing with non-root path in url).
- Fixed default handling for non-existing API in `example/server_integration`.
- Added `md!` and `raw!` to `examples/server_interaction/src/lib.rs` so they are tested.
- Fixed typo in `Makefile.toml`.
- Fixed IDE warning by reordering functions in `examples/websocket/src/server.rs`.
- Updated example in `Readme.md`.


