### PR TITLE
commented out chrome test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_cache:
 
 addons:
   firefox: latest
-  chrome: stable
+#  chrome: stable
 
 env:
   global:
@@ -31,7 +31,8 @@ matrix:
 script:
   - cargo install --force cargo-make # remove --force in the future (https://github.com/rust-lang/cargo/pull/6798)
   - cargo make verify_only # includes `test_h firefox`
-  - cargo make test_h chrome
+#  https://github.com/rustwasm/wasm-pack/issues/611 (don't forget to uncomment Chrome in addons)
+#  - cargo make test_h chrome
 
 # TODO: make it faster ; useful links:
 # https://www.reddit.com/r/rust/comments/9zpyww/idea_a_local_cache_of_compiled_dependencies_in/


### PR DESCRIPTION
There is probably a bug in chromedriver / its configuration in wasm-pack. See failed build in [travis](https://travis-ci.org/David-OConnor/seed/jobs/570685268) and comment in changed `.travis.yml`.

`cargo make test_h chrome` also stopped working on my computer.