### PR TITLE
chrome test workaround, fixed warnings for Rust 1.37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: rust
 rust:
   - stable
 
+#  remove once https://github.com/rustwasm/wasm-pack/issues/611 is resolved
+install:
+  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+  - source ~/.nvm/nvm.sh
+  - nvm install v10.5
+  - npm install -g chromedriver
+  - which chromedriver
+
 os:
 #  - windows   # firefox problem
   - osx
@@ -18,7 +26,7 @@ before_cache:
 
 addons:
   firefox: latest
-#  chrome: stable
+  chrome: stable
 
 env:
   global:
@@ -31,8 +39,7 @@ matrix:
 script:
   - cargo install --force cargo-make # remove --force in the future (https://github.com/rust-lang/cargo/pull/6798)
   - cargo make verify_only # includes `test_h firefox`
-#  https://github.com/rustwasm/wasm-pack/issues/611 (don't forget to uncomment Chrome in addons)
-#  - cargo make test_h chrome
+  - cargo make test_h chrome
 
 # TODO: make it faster ; useful links:
 # https://www.reddit.com/r/rust/comments/9zpyww/idea_a_local_cache_of_compiled_dependencies_in/

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ fn update(msg: Msg, model: &mut Model, _orders: &mut impl Orders<Msg>) {
 /// A simple component.
 fn success_level(clicks: i32) -> Node<Msg> {
     let descrip = match clicks {
-        0 ... 5 => "Not very many 🙁",
-        6 ... 9 => "I got my first real six-string 😐",
-        10 ... 11 => "Spinal Tap 🙂",
+        0 ..= 5 => "Not very many 🙁",
+        6 ..= 9 => "I got my first real six-string 😐",
+        10 ..= 11 => "Spinal Tap 🙂",
         _ => "Double pendulum 🙃"
     };
     p![ descrip ]

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -47,9 +47,9 @@ fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
 /// A simple component.
 fn success_level(clicks: i32) -> Node<Msg> {
     let descrip = match clicks {
-        0...5 => "Not very many 🙁",
-        6...9 => "I got my first real six-string 😐",
-        10...11 => "Spinal Tap 🙂",
+        0..=5 => "Not very many 🙁",
+        6..=9 => "I got my first real six-string 😐",
+        10..=11 => "Spinal Tap 🙂",
         _ => "Double pendulum 🙃",
     };
     p![descrip]

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -471,7 +471,7 @@ impl Request {
         // @TODO: once await/async stabilized, refactor + delete Box
         self.fetch(identity)
             .then(|fetch_object_result| {
-                let mut output_future: Box<
+                let output_future: Box<
                     dyn Future<Item = FetchObject<String>, Error = FetchObject<String>>,
                 >;
 


### PR DESCRIPTION
I haven't solved all issues with PR https://github.com/David-OConnor/seed/pull/199.

1. If you haven't done it yet, upgrade to Rust 1.37 (`rustup update`) because pattern `...` is deprecated and Rust 1.37 has a better algorithm for resolving extra `mut`s in code.

2. Problems with Chrome tests are because of incompatible chromedriver and Chrome. I'll write more details to related issue in `wasm-pack` repo.
I've written workaround to `.travis.yml`. If you want to run `cargo make test_h chrome` in your local PC, just download version compatible with your Chrome from https://chromedriver.chromium.org/downloads and move downloaded chromedriver into the folder that is registered in your `PATH` environment variable.   