### PR TITLE
Add escape hatch from custom routing.

### DIFF
--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -351,12 +351,12 @@ fn view(model: &Model) -> impl View<Msg> {
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn routes(url: seed::Url) -> Msg {
-    match url.path.get(0).map(String::as_str) {
+fn routes(url: seed::Url) -> Option<Msg> {
+    Some(match url.path.get(0).map(String::as_str) {
         Some("active") => Msg::ChangeVisibility(Visible::Active),
         Some("completed") => Msg::ChangeVisibility(Visible::Completed),
         _ => Msg::ChangeVisibility(Visible::All),
-    }
+    })
 }
 
 #[wasm_bindgen(start)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,8 +150,8 @@ pub mod tests {
             vec![mouse_ev("mousemove", |_| Msg::Increment)]
         }
 
-        fn routes(_url: seed::Url) -> Msg {
-            Msg::Increment
+        fn routes(_url: seed::Url) -> Option<Msg> {
+            Some(Msg::Increment)
         }
 
         #[wasm_bindgen]

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -58,7 +58,7 @@ type InitFn<Ms, Mdl, ElC, GMs> =
 type UpdateFn<Ms, Mdl, ElC, GMs> = fn(Ms, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
 type SinkFn<Ms, Mdl, ElC, GMs> = fn(GMs, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
 type ViewFn<Mdl, ElC> = fn(&Mdl) -> ElC;
-type RoutesFn<Ms> = fn(routing::Url) -> Ms;
+type RoutesFn<Ms> = fn(routing::Url) -> Option<Ms>;
 type WindowEvents<Ms, Mdl> = fn(&Mdl) -> Vec<events::Listener<Ms>>;
 type MsgListeners<Ms> = Vec<Box<dyn Fn(&Ms)>>;
 


### PR DESCRIPTION
I was attempting to load in `seed` from an endpoint other than `/`. After a while struggling with attempting to manually route using `web-sys`, I decided to simply provide an escape hatch by allowing routing to return an `Option`.

I hope that the usage is relatively intuitive, but if you return a `None`, routing will fail and fall back to the default operation. If a `Some` is returned, then routing will happen as per the original routing code.

Maybe this should be done a different way? But this was the simplest solution I could think of.