### PR TITLE
Easier debugging, fixed El::Clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbg"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +571,7 @@ name = "seed"
 version = "0.4.1"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -966,6 +975,7 @@ dependencies = [
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+"checksum dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4677188513e0e9d7adced5997cf9a1e7a3c996c994f90093325c5332c1a8b221"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3b762b80547dcf67e427c99ab25dd421fe7d95938c1b10763824555b73b09c7c"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "pulldown-cmark 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,6 +762,11 @@ dependencies = [
 [[package]]
 name = "version_check"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1048,6 +1054,7 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum wasm-bindgen 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "dcddca308b16cd93c2b67b126c688e5467e4ef2e28200dc7dfe4ae284f2faefc"
 "checksum wasm-bindgen-backend 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "f805d9328b5fc7e5c6399960fd1889271b9b58ae17bdb2417472156cc9fafdd0"
 "checksum wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,13 @@ keywords = ["wasm", "webassembly", "frontend", "framework", "web"]
 categories = ["wasm", "web-programming"]
 edition = "2018"
 
+build = "build.rs"
+
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[build-dependencies]
+version_check = "^0.9.1"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2.50" # NOTE: keep in sync with wasm-bindgen version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ serde_json = "^1.0.39"
 # NOTE: keep in sync with wasm-bindgen-test version
 wasm-bindgen = {version = "0.2.50", features = ["serde-serialize"]}
 wasm-bindgen-futures = "0.3.22"
+# @TODO: remove once we can use entities without `Debug` in `log!` and `error!` on `stable` Rust.
+# https://github.com/Centril/rfcs/blob/rfc/quick-debug-macro/text/0000-quick-debug-macro.md#types-which-are-not-debug
+dbg = "1.0.4"
 
 [dependencies.web-sys]
 version = "0.3.27"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+//!
+//! This build script detects if we are nightly or not
+//!
+
+extern crate version_check;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if let Some(true) = version_check::is_feature_flaggable() {
+        println!("cargo:rustc-cfg=use_nightly");
+    }
+}

--- a/examples/drop/src/lib.rs
+++ b/examples/drop/src/lib.rs
@@ -16,9 +16,7 @@ struct Model {
 fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
     Init::new(Model {
         drop_zone_active: false,
-        drop_zone_content: vec![
-            div!["Drop files here"],
-        ]
+        drop_zone_content: vec![div!["Drop files here"]],
     })
 }
 
@@ -45,10 +43,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
                 files.push(file_list.item(index).unwrap());
             }
 
-            model.drop_zone_content = files
-                .iter()
-                .map(|file| div![file.name()])
-                .collect();
+            model.drop_zone_content = files.iter().map(|file| div![file.name()]).collect();
         }
     }
 }
@@ -76,7 +71,6 @@ macro_rules! stop_and_prevent {
 }
 
 fn view(model: &Model) -> impl View<Msg> {
-    log!("DROP EXAMPLE", model.drop_zone_content);
     div![
         style![
             St::Height => px(200),
@@ -116,7 +110,7 @@ fn view(model: &Model) -> impl View<Msg> {
                 // we don't want to fire `DragLeave` when we are dragging over drop-zone children
                 St::PointerEvents => "none",
             },
-            model.drop_zone_content.clone()
+            model.drop_zone_content.clone(),
         ]
     ]
 }

--- a/examples/drop/src/lib.rs
+++ b/examples/drop/src/lib.rs
@@ -8,7 +8,7 @@ use web_sys::{self, DragEvent, Event, FileList};
 
 struct Model {
     drop_zone_active: bool,
-    drop_zone_content: String,
+    drop_zone_content: Vec<Node<Msg>>,
 }
 
 // Init
@@ -16,13 +16,15 @@ struct Model {
 fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
     Init::new(Model {
         drop_zone_active: false,
-        drop_zone_content: "Drop files here".to_owned(),
+        drop_zone_content: vec![
+            div!["Drop files here"],
+        ]
     })
 }
 
 // Update
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum Msg {
     DragEnter,
     DragOver,
@@ -45,7 +47,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
 
             model.drop_zone_content = files
                 .iter()
-                .map(|file| format!("<div>{}</div>", file.name()))
+                .map(|file| div![file.name()])
                 .collect();
         }
     }
@@ -74,6 +76,7 @@ macro_rules! stop_and_prevent {
 }
 
 fn view(model: &Model) -> impl View<Msg> {
+    log!("DROP EXAMPLE", model.drop_zone_content);
     div![
         style![
             St::Height => px(200),
@@ -113,8 +116,7 @@ fn view(model: &Model) -> impl View<Msg> {
                 // we don't want to fire `DragLeave` when we are dragging over drop-zone children
                 St::PointerEvents => "none",
             },
-            // @TODO: Cannot use elements (Nodes) saved in Model - Seed's bug?
-            raw!(&model.drop_zone_content)
+            model.drop_zone_content.clone()
         ]
     ]
 }

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -498,6 +498,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbg"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1307,7 @@ name = "seed"
 version = "0.4.1"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1992,6 +2001,7 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4677188513e0e9d7adced5997cf9a1e7a3c996c994f90093325c5332c1a8b221"
 "checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -1316,6 +1316,7 @@ dependencies = [
  "pulldown-cmark 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1805,6 +1806,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2157,7 @@ dependencies = [
 "checksum v_escape_derive 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "306896ff4b75998501263a1dc000456de442e21d68fe8c8bdf75c66a33a58e23"
 "checksum v_htmlescape 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7fbbe0fa88dd36f9c8cf61a218d4b953ba669de4d0785832f33cc72bd081e1be"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum wasm-bindgen 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "dcddca308b16cd93c2b67b126c688e5467e4ef2e28200dc7dfe4ae284f2faefc"
 "checksum wasm-bindgen-backend 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "f805d9328b5fc7e5c6399960fd1889271b9b58ae17bdb2417472156cc9fafdd0"
 "checksum wasm-bindgen-futures 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "fa1af11c73eca3dc8c51c76ea475a4416e912da6402064a49fc6c0214701866d"

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -67,100 +67,100 @@ pub trait UpdateEl<T> {
     fn update(self, el: &mut T);
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Attrs {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Attrs {
     fn update(self, el: &mut El<Ms>) {
         el.attrs.merge(self);
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for &Attrs {
+impl<Ms: Clone> UpdateEl<El<Ms>> for &Attrs {
     fn update(self, el: &mut El<Ms>) {
         el.attrs.merge(self.clone());
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Style {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Style {
     fn update(self, el: &mut El<Ms>) {
         el.style.merge(self);
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for &Style {
+impl<Ms: Clone> UpdateEl<El<Ms>> for &Style {
     fn update(self, el: &mut El<Ms>) {
         el.style.merge(self.clone());
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Listener<Ms> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Listener<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.listeners.push(self)
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Vec<Listener<Ms>> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Vec<Listener<Ms>> {
     fn update(mut self, el: &mut El<Ms>) {
         el.listeners.append(&mut self);
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for DidMount<Ms> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for DidMount<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.hooks.did_mount = Some(self)
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for DidUpdate<Ms> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for DidUpdate<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.hooks.did_update = Some(self)
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for WillUnmount<Ms> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for WillUnmount<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.hooks.will_unmount = Some(self)
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for &str {
+impl<Ms: Clone> UpdateEl<El<Ms>> for &str {
     // This, or some other mechanism seems to work for String too... note sure why.
     fn update(self, el: &mut El<Ms>) {
         el.children.push(Node::Text(Text::new(self.to_string())))
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for El<Ms> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for El<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.children.push(Node::Element(self))
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Vec<El<Ms>> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Vec<El<Ms>> {
     fn update(self, el: &mut El<Ms>) {
         el.children
             .append(&mut self.into_iter().map(Node::Element).collect());
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Node<Ms> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Node<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.children.push(self)
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Vec<Node<Ms>> {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Vec<Node<Ms>> {
     fn update(mut self, el: &mut El<Ms>) {
         el.children.append(&mut self);
     }
 }
 
 /// This is intended only to be used for the custom! element macro.
-impl<Ms> UpdateEl<El<Ms>> for Tag {
+impl<Ms: Clone> UpdateEl<El<Ms>> for Tag {
     fn update(self, el: &mut El<Ms>) {
         el.tag = self;
     }
 }
 
-impl<Ms, I, U, F> UpdateEl<El<Ms>> for std::iter::Map<I, F>
+impl<Ms: Clone, I, U, F> UpdateEl<El<Ms>> for std::iter::Map<I, F>
 where
     I: Iterator,
     U: UpdateEl<El<Ms>>,
@@ -668,29 +668,29 @@ make_tags! {
     Placeholder => "placeholder"
 }
 
-pub trait View<Ms: 'static> {
+pub trait View<Ms: 'static + Clone> {
     fn els(self) -> Vec<Node<Ms>>;
 }
 
-impl<Ms> View<Ms> for El<Ms> {
+impl<Ms: Clone> View<Ms> for El<Ms> {
     fn els(self) -> Vec<Node<Ms>> {
         vec![Node::Element(self)]
     }
 }
 
-impl<Ms> View<Ms> for Vec<El<Ms>> {
+impl<Ms: Clone> View<Ms> for Vec<El<Ms>> {
     fn els(self) -> Vec<Node<Ms>> {
         self.into_iter().map(Node::Element).collect()
     }
 }
 
-impl<Ms: 'static> View<Ms> for Node<Ms> {
+impl<Ms: 'static + Clone> View<Ms> for Node<Ms> {
     fn els(self) -> Vec<Node<Ms>> {
         vec![self]
     }
 }
 
-impl<Ms: 'static> View<Ms> for Vec<Node<Ms>> {
+impl<Ms: 'static + Clone> View<Ms> for Vec<Node<Ms>> {
     fn els(self) -> Vec<Node<Ms>> {
         self
     }
@@ -721,14 +721,14 @@ impl Text {
 /// An component in our virtual DOM. Related to, but different from
 /// [DOM Nodes](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
 #[derive(Clone, Debug, PartialEq)]
-pub enum Node<Ms: 'static> {
+pub enum Node<Ms: 'static + Clone> {
     Element(El<Ms>),
     //    Svg(El<Ms>),  // May be best to handle using namespace field on El
     Text(Text),
     Empty,
 }
 
-impl<Ms> Node<Ms> {
+impl<Ms: Clone> Node<Ms> {
     fn is_text(&self) -> bool {
         if let Node::Text(_) = self {
             true
@@ -821,7 +821,7 @@ impl<Ms> Node<Ms> {
     }
 }
 
-impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
+impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for Node<Ms> {
     type SelfWithOtherMs = Node<OtherMs>;
     /// See note on impl for El
     fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Node<OtherMs> {
@@ -833,7 +833,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
     }
 }
 
-impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<Node<Ms>> {
+impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for Vec<Node<Ms>> {
     type SelfWithOtherMs = Vec<Node<OtherMs>>;
     fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<Node<OtherMs>> {
         self.into_iter()
@@ -844,7 +844,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<Node<Ms>>
 
 /// An component in our virtual DOM.
 #[derive(Debug)] // todo: Custom debug implementation where children are on new lines and indented.
-pub struct El<Ms: 'static> {
+pub struct El<Ms: 'static + Clone> {
     // Ms is a message type, as in part of TEA.
     // We call this 'El' instead of 'Element' for brevity, and to prevent
     // confusion with web_sys::Element.
@@ -909,7 +909,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for LifecycleHook
     }
 }
 
-impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
+impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for El<Ms> {
     type SelfWithOtherMs = El<OtherMs>;
     /// Maps an element's message to have another message.
     ///
@@ -941,7 +941,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
     }
 }
 
-impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<El<Ms>> {
+impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for Vec<El<Ms>> {
     type SelfWithOtherMs = Vec<El<OtherMs>>;
     fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<El<OtherMs>> {
         self.into_iter()
@@ -950,7 +950,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<El<Ms>> {
     }
 }
 
-impl<Ms> El<Ms> {
+impl<Ms: Clone> El<Ms> {
     /// Create an empty element, specifying only the tag
     pub fn empty(tag: Tag) -> Self {
         Self {
@@ -1083,15 +1083,13 @@ impl<Ms> El<Ms> {
 
 /// Allow the user to clone their Els. Note that there's no easy way to clone the
 /// closures within listeners or lifestyle hooks, so we omit them.
-impl<Ms> Clone for El<Ms> {
+impl<Ms: Clone> Clone for El<Ms> {
     fn clone(&self) -> Self {
         Self {
             tag: self.tag.clone(),
             attrs: self.attrs.clone(),
             style: self.style.clone(),
-            // todo: Put this back - removed during troubleshooting Node change
-            //            children: self.children.clone(),
-            children: Vec::new(),
+            children: self.children.clone(),
             node_ws: self.node_ws.clone(),
             listeners: Vec::new(),
             namespace: self.namespace.clone(),
@@ -1100,7 +1098,7 @@ impl<Ms> Clone for El<Ms> {
     }
 }
 
-impl<Ms> PartialEq for El<Ms> {
+impl<Ms: Clone> PartialEq for El<Ms> {
     fn eq(&self, other: &Self) -> bool {
         // todo Again, note that the listeners check only checks triggers.
         // Don't check children.
@@ -1168,7 +1166,7 @@ pub mod tests {
     use wasm_bindgen::{JsCast, JsValue};
     use web_sys::Element;
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     enum Msg {}
 
     struct Model {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod websys_bridge;
 
 /// Create an element flagged in a way that it will not be rendered. Useful
 /// in ternary operations.
-pub const fn empty<Ms>() -> dom_types::Node<Ms> {
+pub fn empty<Ms: Clone>() -> dom_types::Node<Ms> {
     dom_types::Node::Empty
 }
 

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -12,7 +12,7 @@ use web_sys::{Document, Window};
 
 /// Recursively attach all event-listeners. Run this after creating elements.
 /// The associated `web_sys` nodes must be assigned prior to running this.
-pub(crate) fn attach_listeners<Ms>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
+pub(crate) fn attach_listeners<Ms: Clone>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
     if let Some(el_ws) = el.node_ws.as_ref() {
         for listener in &mut el.listeners {
             listener.attach(el_ws, mailbox.clone());
@@ -26,7 +26,7 @@ pub(crate) fn attach_listeners<Ms>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
 }
 
 /// Recursively detach event-listeners. Run this before patching.
-pub(crate) fn detach_listeners<Ms>(el: &mut El<Ms>) {
+pub(crate) fn detach_listeners<Ms: Clone>(el: &mut El<Ms>) {
     if let Some(el_ws) = el.node_ws.as_ref() {
         for listener in &mut el.listeners {
             listener.detach(el_ws);
@@ -41,7 +41,7 @@ pub(crate) fn detach_listeners<Ms>(el: &mut El<Ms>) {
 
 /// We reattach all listeners, as with normal Els, since we have no
 /// way of diffing them.
-pub(crate) fn setup_window_listeners<Ms>(
+pub(crate) fn setup_window_listeners<Ms: Clone>(
     window: &Window,
     old: &mut Vec<Listener<Ms>>,
     new: &mut Vec<Listener<Ms>>,
@@ -57,7 +57,11 @@ pub(crate) fn setup_window_listeners<Ms>(
 }
 
 /// Remove a node from the vdom and `web_sys` DOM.
-pub(crate) fn remove_node<Ms>(node: &web_sys::Node, parent: &web_sys::Node, el_vdom: &mut El<Ms>) {
+pub(crate) fn remove_node<Ms: Clone>(
+    node: &web_sys::Node,
+    parent: &web_sys::Node,
+    el_vdom: &mut El<Ms>,
+) {
     websys_bridge::remove_node(node, parent);
 
     if let Some(unmount_actions) = &mut el_vdom.hooks.will_unmount {
@@ -72,7 +76,7 @@ pub(crate) fn remove_node<Ms>(node: &web_sys::Node, parent: &web_sys::Node, el_v
 /// model; don't let them get out of sync from typing or other events, which can occur if a change
 /// doesn't trigger a re-render, or if something else modifies them using a side effect.
 /// Handle controlled inputs: Ie force sync with the model.
-fn setup_input_listener<Ms>(el: &mut El<Ms>)
+fn setup_input_listener<Ms: Clone>(el: &mut El<Ms>)
 where
     Ms: 'static,
 {
@@ -99,7 +103,7 @@ where
 }
 
 /// Recursively sets up input listeners
-pub(crate) fn setup_input_listeners<Ms>(el_vdom: &mut El<Ms>)
+pub(crate) fn setup_input_listeners<Ms: Clone>(el_vdom: &mut El<Ms>)
 where
     Ms: 'static,
 {
@@ -111,7 +115,7 @@ where
     }
 }
 
-fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
+fn patch_el<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     mut old: El<Ms>,
     new: &'a mut El<Ms>,
@@ -193,7 +197,7 @@ fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     new.node_ws.as_ref()
 }
 
-pub(crate) fn patch_els<'a, Ms, Mdl, ElC, GMs, OI, NI>(
+pub(crate) fn patch_els<'a, Ms: Clone, Mdl, ElC, GMs, OI, NI>(
     document: &Document,
     mailbox: &Mailbox<Ms>,
     app: &App<Ms, Mdl, ElC, GMs>,
@@ -278,7 +282,7 @@ pub(crate) fn patch_els<'a, Ms, Mdl, ElC, GMs, OI, NI>(
 }
 
 // Reduces code repetition
-fn add_el_helper<Ms>(
+fn add_el_helper<Ms: Clone>(
     new: &mut El<Ms>,
     parent: &web_sys::Node,
     next_node: Option<web_sys::Node>,
@@ -302,7 +306,7 @@ fn add_el_helper<Ms>(
 
 /// Routes patching through different channels, depending on the Node variant
 /// of old and new.
-pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
+pub(crate) fn patch<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     old: Node<Ms>,
     new: &'a mut Node<Ms>,

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -320,15 +320,23 @@ macro_rules! style {
 //
 //}
 
+pub fn wrap_debug<T>(object: T) -> dbg::WrapDebug<T> {
+    dbg::WrapDebug(object)
+}
+
 /// A convenience function for logging to the web browser's console.  We use
 /// a macro to supplement the log function to allow multiple inputs.
+///
+/// NOTE: `log!` also accepts entities which don't implement `Debug` on `nightly` Rust.
+/// It's useful because you don't have to add `Debug` bound to many places - implementation for
+/// logged entity is enough.
 #[macro_export]
 macro_rules! log {
     { $($expr:expr),* $(,)? } => {
         {
             let mut formatted_exprs = Vec::new();
             $(
-                formatted_exprs.push(format!("{:#?}", $expr));
+                formatted_exprs.push(format!("{:#?}", $crate::shortcuts::wrap_debug(&$expr)));
             )*
             $crate::shortcuts::log_1(
                 &formatted_exprs
@@ -351,7 +359,7 @@ macro_rules! error {
         {
             let mut formatted_exprs = Vec::new();
             $(
-                formatted_exprs.push(format!("{:#?}", $expr));
+                formatted_exprs.push(format!("{:#?}", $crate::shortcuts::wrap_debug(&$expr)));
             )*
             $crate::shortcuts::error_1(
                 &formatted_exprs

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -27,7 +27,9 @@ macro_rules! element {
                             {
                                 #[allow(unused_mut)]
                                 let mut el = El::empty($crate::dom_types::Tag::$Tag_camel);
-                                $d ( $d part.update(&mut el); )*
+                                $d (
+                                    $d part.update(&mut el);
+                                )*
                                 $crate::dom_types::Node::Element(el)
                             }
                         };
@@ -320,8 +322,14 @@ macro_rules! style {
 //
 //}
 
+#[cfg(use_nightly)]
 pub fn wrap_debug<T>(object: T) -> dbg::WrapDebug<T> {
     dbg::WrapDebug(object)
+}
+
+#[cfg(not(use_nightly))]
+pub fn wrap_debug<T: std::fmt::Debug>(object: T) -> T {
+    object
 }
 
 /// A convenience function for logging to the web browser's console.  We use

--- a/src/util.rs
+++ b/src/util.rs
@@ -193,14 +193,31 @@ impl<T> ClosureNew<T> for Closure<T> {
 
 /// Convenience function for logging to the web browser's console.  See also
 /// the log! macro, which is more flexible.
+#[cfg(use_nightly)]
 pub fn log<T>(object: T) -> T {
     web_sys::console::log_1(&format!("{:#?}", dbg::WrapDebug(&object)).into());
     object
 }
 
+/// Convenience function for logging to the web browser's console.  See also
+/// the log! macro, which is more flexible.
+#[cfg(not(use_nightly))]
+pub fn log<T: std::fmt::Debug>(object: T) -> T {
+    web_sys::console::log_1(&format!("{:#?}", &object).into());
+    object
+}
+
 /// Similar to log, but for errors.
+#[cfg(use_nightly)]
 pub fn error<T>(object: T) -> T {
     web_sys::console::error_1(&format!("{:#?}", dbg::WrapDebug(&object)).into());
+    object
+}
+
+/// Similar to log, but for errors.
+#[cfg(not(use_nightly))]
+pub fn error<T: std::fmt::Debug>(object: T) -> T {
+    web_sys::console::error_1(&format!("{:#?}", &object).into());
     object
 }
 
@@ -228,4 +245,3 @@ where
         .dispatch_event(&event)
         .expect("Error: TriggerUpdate - dispatch)event failed!");
 }
-

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,6 @@
 //! This module is decoupled / independent.
 
 use crate::events;
-use std::fmt;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use web_sys;
@@ -194,13 +193,15 @@ impl<T> ClosureNew<T> for Closure<T> {
 
 /// Convenience function for logging to the web browser's console.  See also
 /// the log! macro, which is more flexible.
-pub fn log<D: fmt::Debug>(text: D) {
-    web_sys::console::log_1(&format!("{:#?}", &text).into());
+pub fn log<T>(object: T) -> T {
+    web_sys::console::log_1(&format!("{:#?}", dbg::WrapDebug(&object)).into());
+    object
 }
 
 /// Similar to log, but for errors.
-pub fn error<D: fmt::Debug>(text: D) {
-    web_sys::console::error_1(&format!("{:#?}", &text).into());
+pub fn error<T>(object: T) -> T {
+    web_sys::console::error_1(&format!("{:#?}", dbg::WrapDebug(&object)).into());
+    object
 }
 
 /// Trigger update function.
@@ -227,3 +228,4 @@ where
         .dispatch_event(&event)
         .expect("Error: TriggerUpdate - dispatch)event failed!");
 }
+

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -123,7 +123,7 @@ impl<Ms> Clone for Mailbox<Ms> {
 type StoredPopstate = RefCell<Option<Closure<dyn FnMut(Event)>>>;
 
 /// Used as part of an interior-mutability pattern, ie Rc<RefCell<>>
-pub struct AppData<Ms: 'static, Mdl> {
+pub struct AppData<Ms: 'static + Clone, Mdl> {
     // Model is in a RefCell here so we can modify it in self.update().
     pub model: RefCell<Option<Mdl>>,
     main_el_vdom: RefCell<Option<El<Ms>>>,
@@ -134,7 +134,7 @@ pub struct AppData<Ms: 'static, Mdl> {
     scheduled_render_handle: RefCell<Option<util::RequestAnimationFrameHandle>>,
 }
 
-pub struct AppCfg<Ms, Mdl, ElC, GMs>
+pub struct AppCfg<Ms: Clone, Mdl, ElC, GMs>
 where
     Ms: 'static,
     Mdl: 'static,
@@ -149,7 +149,7 @@ where
     initial_orders: RefCell<Option<OrdersContainer<Ms, Mdl, ElC, GMs>>>,
 }
 
-pub struct App<Ms, Mdl, ElC, GMs = ()>
+pub struct App<Ms: Clone, Mdl, ElC, GMs = ()>
 where
     Ms: 'static,
     Mdl: 'static,
@@ -161,7 +161,9 @@ where
     pub data: Rc<AppData<Ms, Mdl>>,
 }
 
-impl<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs> ::std::fmt::Debug for App<Ms, Mdl, ElC, GMs> {
+impl<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs> ::std::fmt::Debug
+    for App<Ms, Mdl, ElC, GMs>
+{
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "App")
     }
@@ -196,7 +198,7 @@ impl MountPoint for web_sys::HtmlElement {
 }
 
 /// Used to create and store initial app configuration, ie items passed by the app creator
-pub struct AppBuilder<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs> {
+pub struct AppBuilder<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs> {
     init: InitFn<Ms, Mdl, ElC, GMs>,
     update: UpdateFn<Ms, Mdl, ElC, GMs>,
     sink: Option<SinkFn<Ms, Mdl, ElC, GMs>>,
@@ -206,7 +208,7 @@ pub struct AppBuilder<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs> {
     window_events: Option<WindowEvents<Ms, Mdl>>,
 }
 
-impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, ElC, GMs> {
+impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, ElC, GMs> {
     /// Choose the element where the application will be mounted.
     /// The default one is the element with `id` = "app".
     ///
@@ -297,7 +299,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, ElC, GM
 
 /// We use a struct instead of series of functions, in order to avoid passing
 /// repetitive sequences of parameters.
-impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
+impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
     pub fn build(
         init: impl FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl> + 'static,
         update: UpdateFn<Ms, Mdl, ElC, GMs>,
@@ -623,7 +625,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
     }
 }
 
-impl<Ms, Mdl, ElC: View<Ms>, GMs> Clone for App<Ms, Mdl, ElC, GMs> {
+impl<Ms: Clone, Mdl, ElC: View<Ms>, GMs> Clone for App<Ms, Mdl, ElC, GMs> {
     fn clone(&self) -> Self {
         Self {
             cfg: Rc::clone(&self.cfg),
@@ -665,7 +667,7 @@ pub trait _DomEl<Ms>: Sized + PartialEq + DomElLifecycle {
     fn children(self) -> Vec<Self>;
     fn websys_el(self) -> Option<web_sys::Element>;
     fn id(self) -> Option<u32>;
-    // TODO: tying to dom_types is temp - defeats the urpose of the trait
+    // TODO: tying to dom_types is temp - defeats the purpose of the trait
     fn namespace(self) -> Option<Namespace>;
 
     // Methods
@@ -1337,6 +1339,7 @@ pub mod tests {
             counters: Counters,
             test_value_sender: Option<futures::sync::oneshot::Sender<Counters>>,
         }
+        #[derive(Clone)]
         enum Msg {
             MessageReceived,
             CommandPerformed,

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -57,7 +57,7 @@ fn set_attr_value(el_ws: &web_sys::Node, at: &dom_types::At, at_value: &AtValue)
                         .set_attribute(at.as_str(), value)
                         .map_err(|_| "Problem setting an atrribute.")
                 })
-                .unwrap_or_else(crate::error);
+                .unwrap_or_else(|err| { crate::error(err); });
         }
         AtValue::None => {
             node_to_element(el_ws)
@@ -66,7 +66,7 @@ fn set_attr_value(el_ws: &web_sys::Node, at: &dom_types::At, at_value: &AtValue)
                         .set_attribute(at.as_str(), "")
                         .map_err(|_| "Problem setting an atrribute.")
                 })
-                .unwrap_or_else(crate::error);
+                .unwrap_or_else(|err| { crate::error(err); });
         }
         AtValue::Ignored => {
             node_to_element(el_ws)
@@ -75,7 +75,7 @@ fn set_attr_value(el_ws: &web_sys::Node, at: &dom_types::At, at_value: &AtValue)
                         .remove_attribute(at.as_str())
                         .map_err(|_| "Problem removing an atrribute.")
                 })
-                .unwrap_or_else(crate::error);
+                .unwrap_or_else(|err| { crate::error(err); });
         }
     }
 }
@@ -169,10 +169,13 @@ pub fn attach_el_and_children<Ms>(el_vdom: &mut El<Ms>, parent: &web_sys::Node) 
 
     // appending the its children to the el_ws
     for child in &mut el_vdom.children {
+        log!(child);
         match child {
             // Raise the active level once per recursion.
             Node::Element(child_el) => attach_el_and_children(child_el, el_ws),
-            Node::Text(child_text) => attach_text_node(child_text, el_ws),
+            Node::Text(child_text) => {
+                attach_text_node(child_text, el_ws)
+            },
             Node::Empty => (),
         }
     }
@@ -256,7 +259,7 @@ pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_
                 },
                 _ => Ok(()),
             }
-            .unwrap_or_else(crate::error)
+            .unwrap_or_else(|err| { crate::error(err); })
         }
         // Remove attributes that aren't in the new vdom.
         for name in old.attrs.vals.keys() {
@@ -266,7 +269,7 @@ pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_
                     Some(el) => el
                         .remove_attribute(name.as_str())
                         .expect("Removing an attribute"),
-                    None => crate::error("Minor error on html element (setting attrs)"),
+                    None => { crate::error("Minor error on html element (setting attrs)"); },
                 }
             }
         }


### PR DESCRIPTION
Changes
  - `log` and `error` returns input, so we can use them as wrappers.
  - `log`, `log!`, `error` and `error!` accepts non-`Debug` objects on `nightly` Rust. Why? You can write `log!(my_element);` somewhere in Seed and you don't have to add `Ms: Debug` on 1569 places in code.
  - Fixed `Clone` implementation for `El` - yeah, we should take `todos` more seriously.. ; It fixes `Drop` example; A little bit breaking change, because `Msg` has to implement `Clone`. But if you use at least one event handler in your app, you already implemented it.

@David-OConnor Could you please test `log`, `error`, `log!` and `error!` on `stable` and `nightly` before merge? I'm not sure if I tested it properly and you'll maybe find out some problems which I don't see.