### PR TITLE
Change vdom bootstrapping to occur before the initial orders are processed.

### DIFF
--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -720,7 +720,7 @@ impl Text {
     pub fn get_text(&self) -> String {
         self.text.to_string()
     }
-    pub fn strip_ws_nodes(&mut self) {
+    pub fn strip_ws_node(&mut self) {
         self.node_ws.take();
     }
 }
@@ -827,10 +827,10 @@ impl<Ms> Node<Ms> {
 }
 // Workspace manipulations.
 impl<Ms> Node<Ms> {
-    pub(crate) fn strip_ws_nodes(&mut self) -> &mut Self {
+    pub(crate) fn strip_own_and_children_ws_nodes(&mut self) -> &mut Self {
         match self {
-            Node::Element(e) => e.strip_ws_nodes(),
-            Node::Text(t) => t.strip_ws_nodes(),
+            Node::Element(e) => e.strip_own_and_children_ws_nodes(),
+            Node::Text(t) => t.strip_ws_node(),
             _ => (),
         }
         self
@@ -930,10 +930,11 @@ pub struct El<Ms: 'static> {
     pub hooks: LifecycleHooks<Ms>,
 }
 impl<Ms> El<Ms> {
-    pub(crate) fn strip_ws_nodes(&mut self) {
+    /// Strips ws nodes in the children as well.
+    pub(crate) fn strip_own_and_children_ws_nodes(&mut self) {
         self.node_ws.take();
         for child in &mut self.children {
-            child.strip_ws_nodes();
+            child.strip_own_and_children_ws_nodes();
         }
     }
 }

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -67,100 +67,100 @@ pub trait UpdateEl<T> {
     fn update(self, el: &mut T);
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for Attrs {
+impl<Ms> UpdateEl<El<Ms>> for Attrs {
     fn update(self, el: &mut El<Ms>) {
         el.attrs.merge(self);
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for &Attrs {
+impl<Ms> UpdateEl<El<Ms>> for &Attrs {
     fn update(self, el: &mut El<Ms>) {
         el.attrs.merge(self.clone());
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for Style {
+impl<Ms> UpdateEl<El<Ms>> for Style {
     fn update(self, el: &mut El<Ms>) {
         el.style.merge(self);
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for &Style {
+impl<Ms> UpdateEl<El<Ms>> for &Style {
     fn update(self, el: &mut El<Ms>) {
         el.style.merge(self.clone());
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for Listener<Ms> {
+impl<Ms> UpdateEl<El<Ms>> for Listener<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.listeners.push(self)
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for Vec<Listener<Ms>> {
+impl<Ms> UpdateEl<El<Ms>> for Vec<Listener<Ms>> {
     fn update(mut self, el: &mut El<Ms>) {
         el.listeners.append(&mut self);
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for DidMount<Ms> {
+impl<Ms> UpdateEl<El<Ms>> for DidMount<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.hooks.did_mount = Some(self)
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for DidUpdate<Ms> {
+impl<Ms> UpdateEl<El<Ms>> for DidUpdate<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.hooks.did_update = Some(self)
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for WillUnmount<Ms> {
+impl<Ms> UpdateEl<El<Ms>> for WillUnmount<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.hooks.will_unmount = Some(self)
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for &str {
+impl<Ms> UpdateEl<El<Ms>> for &str {
     // This, or some other mechanism seems to work for String too... note sure why.
     fn update(self, el: &mut El<Ms>) {
         el.children.push(Node::Text(Text::new(self.to_string())))
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for El<Ms> {
+impl<Ms> UpdateEl<El<Ms>> for El<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.children.push(Node::Element(self))
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for Vec<El<Ms>> {
+impl<Ms> UpdateEl<El<Ms>> for Vec<El<Ms>> {
     fn update(self, el: &mut El<Ms>) {
         el.children
             .append(&mut self.into_iter().map(Node::Element).collect());
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for Node<Ms> {
+impl<Ms> UpdateEl<El<Ms>> for Node<Ms> {
     fn update(self, el: &mut El<Ms>) {
         el.children.push(self)
     }
 }
 
-impl<Ms: Clone> UpdateEl<El<Ms>> for Vec<Node<Ms>> {
+impl<Ms> UpdateEl<El<Ms>> for Vec<Node<Ms>> {
     fn update(mut self, el: &mut El<Ms>) {
         el.children.append(&mut self);
     }
 }
 
 /// This is intended only to be used for the custom! element macro.
-impl<Ms: Clone> UpdateEl<El<Ms>> for Tag {
+impl<Ms> UpdateEl<El<Ms>> for Tag {
     fn update(self, el: &mut El<Ms>) {
         el.tag = self;
     }
 }
 
-impl<Ms: Clone, I, U, F> UpdateEl<El<Ms>> for std::iter::Map<I, F>
+impl<Ms, I, U, F> UpdateEl<El<Ms>> for std::iter::Map<I, F>
 where
     I: Iterator,
     U: UpdateEl<El<Ms>>,
@@ -669,29 +669,29 @@ make_tags! {
     Placeholder => "placeholder"
 }
 
-pub trait View<Ms: 'static + Clone> {
+pub trait View<Ms: 'static> {
     fn els(self) -> Vec<Node<Ms>>;
 }
 
-impl<Ms: Clone> View<Ms> for El<Ms> {
+impl<Ms> View<Ms> for El<Ms> {
     fn els(self) -> Vec<Node<Ms>> {
         vec![Node::Element(self)]
     }
 }
 
-impl<Ms: Clone> View<Ms> for Vec<El<Ms>> {
+impl<Ms> View<Ms> for Vec<El<Ms>> {
     fn els(self) -> Vec<Node<Ms>> {
         self.into_iter().map(Node::Element).collect()
     }
 }
 
-impl<Ms: 'static + Clone> View<Ms> for Node<Ms> {
+impl<Ms: 'static> View<Ms> for Node<Ms> {
     fn els(self) -> Vec<Node<Ms>> {
         vec![self]
     }
 }
 
-impl<Ms: 'static + Clone> View<Ms> for Vec<Node<Ms>> {
+impl<Ms: 'static> View<Ms> for Vec<Node<Ms>> {
     fn els(self) -> Vec<Node<Ms>> {
         self
     }
@@ -727,16 +727,25 @@ impl Text {
 
 /// An component in our virtual DOM. Related to, but different from
 /// [DOM Nodes](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
-#[derive(Clone, Debug, PartialEq)]
-pub enum Node<Ms: 'static + Clone> {
+#[derive(Debug, PartialEq)]
+pub enum Node<Ms: 'static> {
     Element(El<Ms>),
     //    Svg(El<Ms>),  // May be best to handle using namespace field on El
     Text(Text),
     Empty,
 }
+impl<Ms: 'static> Clone for Node<Ms> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Element(e) => Self::Element(e.clone()),
+            Self::Text(t) => Self::Text(t.clone()),
+            Self::Empty => Self::Empty,
+        }
+    }
+}
 
 // Mappers for `El` manipulations.
-impl<Ms: Clone> Node<Ms> {
+impl<Ms> Node<Ms> {
     /// See `El::from_markdown`
     pub fn from_markdown(markdown: &str) -> Vec<Node<Ms>> {
         El::from_markdown(markdown)
@@ -817,7 +826,7 @@ impl<Ms: Clone> Node<Ms> {
     }
 }
 // Workspace manipulations.
-impl<Ms: Clone> Node<Ms> {
+impl<Ms> Node<Ms> {
     pub(crate) fn strip_ws_nodes(&mut self) -> &mut Self {
         match self {
             Node::Element(e) => e.strip_ws_nodes(),
@@ -828,7 +837,7 @@ impl<Ms: Clone> Node<Ms> {
     }
 }
 // Convenience methods for `Node` a la `Result` and `Option`.
-impl<Ms: Clone> Node<Ms> {
+impl<Ms> Node<Ms> {
     pub fn new_text(text: impl Into<Cow<'static, str>>) -> Self {
         Node::Text(Text::new(text))
     }
@@ -883,7 +892,7 @@ impl<Ms: Clone> Node<Ms> {
     }
 }
 
-impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for Node<Ms> {
+impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
     type SelfWithOtherMs = Node<OtherMs>;
     /// See note on impl for El
     fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Node<OtherMs> {
@@ -895,7 +904,7 @@ impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> f
     }
 }
 
-impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for Vec<Node<Ms>> {
+impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<Node<Ms>> {
     type SelfWithOtherMs = Vec<Node<OtherMs>>;
     fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<Node<OtherMs>> {
         self.into_iter()
@@ -906,7 +915,7 @@ impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> f
 
 /// An component in our virtual DOM.
 #[derive(Debug)] // todo: Custom debug implementation where children are on new lines and indented.
-pub struct El<Ms: 'static + Clone> {
+pub struct El<Ms: 'static> {
     // Ms is a message type, as in part of TEA.
     // We call this 'El' instead of 'Element' for brevity, and to prevent
     // confusion with web_sys::Element.
@@ -920,7 +929,7 @@ pub struct El<Ms: 'static + Clone> {
     pub namespace: Option<Namespace>,
     pub hooks: LifecycleHooks<Ms>,
 }
-impl<Ms: Clone> El<Ms> {
+impl<Ms> El<Ms> {
     pub(crate) fn strip_ws_nodes(&mut self) {
         self.node_ws.take();
         for child in &mut self.children {
@@ -979,7 +988,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for LifecycleHook
     }
 }
 
-impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for El<Ms> {
+impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
     type SelfWithOtherMs = El<OtherMs>;
     /// Maps an element's message to have another message.
     ///
@@ -1011,7 +1020,7 @@ impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> f
     }
 }
 
-impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for Vec<El<Ms>> {
+impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<El<Ms>> {
     type SelfWithOtherMs = Vec<El<OtherMs>>;
     fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<El<OtherMs>> {
         self.into_iter()
@@ -1020,7 +1029,7 @@ impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> f
     }
 }
 
-impl<Ms: Clone> El<Ms> {
+impl<Ms> El<Ms> {
     /// Create an empty element, specifying only the tag
     pub fn empty(tag: Tag) -> Self {
         Self {
@@ -1153,7 +1162,7 @@ impl<Ms: Clone> El<Ms> {
 
 /// Allow the user to clone their Els. Note that there's no easy way to clone the
 /// closures within listeners or lifestyle hooks, so we omit them.
-impl<Ms: Clone> Clone for El<Ms> {
+impl<Ms> Clone for El<Ms> {
     fn clone(&self) -> Self {
         Self {
             tag: self.tag.clone(),
@@ -1168,7 +1177,7 @@ impl<Ms: Clone> Clone for El<Ms> {
     }
 }
 
-impl<Ms: Clone> PartialEq for El<Ms> {
+impl<Ms> PartialEq for El<Ms> {
     fn eq(&self, other: &Self) -> bool {
         // todo Again, note that the listeners check only checks triggers.
         // Don't check children.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ mod websys_bridge;
 
 /// Create an element flagged in a way that it will not be rendered. Useful
 /// in ternary operations.
-pub fn empty<Ms: Clone>() -> dom_types::Node<Ms> {
+pub const fn empty<Ms>() -> dom_types::Node<Ms> {
     dom_types::Node::Empty
 }
 
@@ -133,7 +133,6 @@ pub mod tests {
             }
         }
 
-        #[derive(Clone)]
         enum Msg {
             Increment,
         }

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -5,8 +5,8 @@ use std::{collections::VecDeque, convert::identity, rc::Rc};
 
 // ------ Orders ------
 
-pub trait Orders<Ms: 'static + Clone, GMs = ()> {
-    type AppMs: 'static + Clone;
+pub trait Orders<Ms: 'static, GMs = ()> {
+    type AppMs: 'static;
     type Mdl: 'static;
     type ElC: View<Self::AppMs> + 'static;
 
@@ -19,7 +19,7 @@ pub trait Orders<Ms: 'static + Clone, GMs = ()> {
     ///    child::update(child_msg, &mut model.child, &mut orders.proxy(Msg::Child));
     ///}
     /// ```
-    fn proxy<ChildMs: 'static + Clone>(
+    fn proxy<ChildMs: 'static>(
         &mut self,
         f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
     ) -> OrdersProxy<ChildMs, Self::AppMs, Self::Mdl, Self::ElC, GMs>;
@@ -80,13 +80,13 @@ pub trait Orders<Ms: 'static + Clone, GMs = ()> {
 // ------ OrdersContainer ------
 
 #[allow(clippy::module_name_repetitions)]
-pub struct OrdersContainer<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs = ()> {
+pub struct OrdersContainer<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs = ()> {
     pub(crate) should_render: ShouldRender,
     pub(crate) effects: VecDeque<Effect<Ms, GMs>>,
     app: App<Ms, Mdl, ElC, GMs>,
 }
 
-impl<Ms: Clone, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
+impl<Ms, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
     pub fn new(app: App<Ms, Mdl, ElC, GMs>) -> Self {
         Self {
             should_render: ShouldRender::Render,
@@ -96,7 +96,7 @@ impl<Ms: Clone, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
     }
 }
 
-impl<Ms: 'static + Clone, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
+impl<Ms: 'static, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
     for OrdersContainer<Ms, Mdl, ElC, GMs>
 {
     type AppMs = Ms;
@@ -104,7 +104,7 @@ impl<Ms: 'static + Clone, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
     type ElC = ElC;
 
     #[allow(clippy::redundant_closure)]
-    fn proxy<ChildMs: 'static + Clone>(
+    fn proxy<ChildMs: 'static>(
         &mut self,
         f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
     ) -> OrdersProxy<ChildMs, Ms, Mdl, ElC, GMs> {
@@ -167,19 +167,12 @@ impl<Ms: 'static + Clone, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
 // ------ OrdersProxy ------
 
 #[allow(clippy::module_name_repetitions)]
-pub struct OrdersProxy<
-    'a,
-    Ms: Clone,
-    AppMs: 'static + Clone,
-    Mdl: 'static,
-    ElC: View<AppMs>,
-    GMs: 'static = (),
-> {
+pub struct OrdersProxy<'a, Ms, AppMs: 'static, Mdl: 'static, ElC: View<AppMs>, GMs: 'static = ()> {
     orders_container: &'a mut OrdersContainer<AppMs, Mdl, ElC, GMs>,
     f: Rc<dyn Fn(Ms) -> AppMs>,
 }
 
-impl<'a, Ms: 'static + Clone, AppMs: 'static + Clone, Mdl, ElC: View<AppMs>, GMs>
+impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs>, GMs>
     OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
 {
     pub fn new(
@@ -193,14 +186,14 @@ impl<'a, Ms: 'static + Clone, AppMs: 'static + Clone, Mdl, ElC: View<AppMs>, GMs
     }
 }
 
-impl<'a, Ms: 'static + Clone, AppMs: 'static + Clone, Mdl, ElC: View<AppMs> + 'static, GMs>
-    Orders<Ms, GMs> for OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
+impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs> + 'static, GMs> Orders<Ms, GMs>
+    for OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
 {
     type AppMs = AppMs;
     type Mdl = Mdl;
     type ElC = ElC;
 
-    fn proxy<ChildMs: 'static + Clone>(
+    fn proxy<ChildMs: 'static>(
         &mut self,
         f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
     ) -> OrdersProxy<ChildMs, AppMs, Mdl, ElC, GMs> {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -12,7 +12,7 @@ use web_sys::{Document, Window};
 
 /// Recursively attach all event-listeners. Run this after creating elements.
 /// The associated `web_sys` nodes must be assigned prior to running this.
-pub(crate) fn attach_listeners<Ms: Clone>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
+pub(crate) fn attach_listeners<Ms>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
     if let Some(el_ws) = el.node_ws.as_ref() {
         for listener in &mut el.listeners {
             listener.attach(el_ws, mailbox.clone());
@@ -26,7 +26,7 @@ pub(crate) fn attach_listeners<Ms: Clone>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>
 }
 
 /// Recursively detach event-listeners. Run this before patching.
-pub(crate) fn detach_listeners<Ms: Clone>(el: &mut El<Ms>) {
+pub(crate) fn detach_listeners<Ms>(el: &mut El<Ms>) {
     if let Some(el_ws) = el.node_ws.as_ref() {
         for listener in &mut el.listeners {
             listener.detach(el_ws);
@@ -41,7 +41,7 @@ pub(crate) fn detach_listeners<Ms: Clone>(el: &mut El<Ms>) {
 
 /// We reattach all listeners, as with normal Els, since we have no
 /// way of diffing them.
-pub(crate) fn setup_window_listeners<Ms: Clone>(
+pub(crate) fn setup_window_listeners<Ms>(
     window: &Window,
     old: &mut Vec<Listener<Ms>>,
     new: &mut Vec<Listener<Ms>>,
@@ -57,11 +57,7 @@ pub(crate) fn setup_window_listeners<Ms: Clone>(
 }
 
 /// Remove a node from the vdom and `web_sys` DOM.
-pub(crate) fn remove_node<Ms: Clone>(
-    node: &web_sys::Node,
-    parent: &web_sys::Node,
-    el_vdom: &mut El<Ms>,
-) {
+pub(crate) fn remove_node<Ms>(node: &web_sys::Node, parent: &web_sys::Node, el_vdom: &mut El<Ms>) {
     websys_bridge::remove_node(node, parent);
 
     if let Some(unmount_actions) = &mut el_vdom.hooks.will_unmount {
@@ -76,7 +72,7 @@ pub(crate) fn remove_node<Ms: Clone>(
 /// model; don't let them get out of sync from typing or other events, which can occur if a change
 /// doesn't trigger a re-render, or if something else modifies them using a side effect.
 /// Handle controlled inputs: Ie force sync with the model.
-fn setup_input_listener<Ms: Clone>(el: &mut El<Ms>)
+fn setup_input_listener<Ms>(el: &mut El<Ms>)
 where
     Ms: 'static,
 {
@@ -103,7 +99,7 @@ where
 }
 
 /// Recursively sets up input listeners
-pub(crate) fn setup_input_listeners<Ms: Clone>(el_vdom: &mut El<Ms>)
+pub(crate) fn setup_input_listeners<Ms>(el_vdom: &mut El<Ms>)
 where
     Ms: 'static,
 {
@@ -115,7 +111,7 @@ where
     }
 }
 
-fn patch_el<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
+fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     mut old: El<Ms>,
     new: &'a mut El<Ms>,
@@ -197,7 +193,7 @@ fn patch_el<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
     new.node_ws.as_ref()
 }
 
-pub(crate) fn patch_els<'a, Ms: Clone, Mdl, ElC, GMs, OI, NI>(
+pub(crate) fn patch_els<'a, Ms, Mdl, ElC, GMs, OI, NI>(
     document: &Document,
     mailbox: &Mailbox<Ms>,
     app: &App<Ms, Mdl, ElC, GMs>,
@@ -282,7 +278,7 @@ pub(crate) fn patch_els<'a, Ms: Clone, Mdl, ElC, GMs, OI, NI>(
 }
 
 // Reduces code repetition
-fn add_el_helper<Ms: Clone>(
+fn add_el_helper<Ms>(
     new: &mut El<Ms>,
     parent: &web_sys::Node,
     next_node: Option<web_sys::Node>,
@@ -306,7 +302,7 @@ fn add_el_helper<Ms: Clone>(
 
 /// Routes patching through different channels, depending on the Node variant
 /// of old and new.
-pub(crate) fn patch<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
+pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     old: Node<Ms>,
     new: &'a mut Node<Ms>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -231,7 +231,7 @@ pub fn error<T: std::fmt::Debug>(object: T) -> T {
 #[deprecated]
 pub fn update<Ms>(msg: Ms)
 where
-    Ms: Clone + 'static + serde::Serialize,
+    Ms: 'static + serde::Serialize,
 {
     let msg_as_js_value = wasm_bindgen::JsValue::from_serde(&msg)
         .expect("Error: TriggerUpdate - can't serialize given msg!");

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -494,7 +494,7 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GM
         // render as per normal for seed behavior. -- Executed here to ensure that all state has
         // been initialized with a bootstrap version. The bootstrap will be replaced after first
         // render.
-        self.process_cmd_and_msg_queue(
+        self.process_cmd_and_msg_queue_with_forced_render(
             self.cfg
                 .initial_orders
                 .replace(None)
@@ -528,6 +528,10 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GM
         self.process_cmd_and_msg_queue(queue);
     }
 
+    pub fn process_cmd_and_msg_queue_with_forced_render(&self, queue: VecDeque<Effect<Ms, GMs>>) {
+        self.process_cmd_and_msg_queue(queue);
+        self.rerender_vdom();
+    }
     pub fn process_cmd_and_msg_queue(&self, mut queue: VecDeque<Effect<Ms, GMs>>) {
         while let Some(effect) = queue.pop_front() {
             match effect {

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -21,19 +21,23 @@ use crate::{
     websys_bridge,
 };
 
+mod alias;
+mod builder;
+
+pub use alias::*;
+pub use builder::{Builder as AppBuilder, Init, Initializer, UrlHandling};
+
 pub enum Effect<Ms, GMs> {
     Msg(Ms),
     Cmd(Box<dyn Future<Item = Ms, Error = Ms> + 'static>),
     GMsg(GMs),
     GCmd(Box<dyn Future<Item = GMs, Error = GMs> + 'static>),
 }
-
 impl<Ms, GMs> From<Ms> for Effect<Ms, GMs> {
     fn from(message: Ms) -> Self {
         Effect::Msg(message)
     }
 }
-
 impl<Ms: 'static, OtherMs: 'static, GMs> MessageMapper<Ms, OtherMs> for Effect<Ms, GMs> {
     type SelfWithOtherMs = Effect<OtherMs, GMs>;
     fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Effect<OtherMs, GMs> {
@@ -51,47 +55,6 @@ pub enum ShouldRender {
     Render,
     ForceRenderNow,
     Skip,
-}
-
-//type InitFn<Ms, Mdl, ElC, GMs> =
-//    Box<dyn FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Mdl>;
-type InitFn<Ms, Mdl, ElC, GMs> =
-    Box<dyn FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>;
-type UpdateFn<Ms, Mdl, ElC, GMs> = fn(Ms, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
-type SinkFn<Ms, Mdl, ElC, GMs> = fn(GMs, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
-type ViewFn<Mdl, ElC> = fn(&Mdl) -> ElC;
-type RoutesFn<Ms> = fn(routing::Url) -> Option<Ms>;
-type WindowEvents<Ms, Mdl> = fn(&Mdl) -> Vec<events::Listener<Ms>>;
-type MsgListeners<Ms> = Vec<Box<dyn Fn(&Ms)>>;
-
-/// Used for handling initial routing.
-pub enum UrlHandling {
-    PassToRoutes,
-    None,
-    // todo: Expand later, as-required
-}
-
-/// Used as a flexible wrapper for the init function.
-pub struct Init<Mdl> {
-    //    init: InitFn<Ms, Mdl, ElC, GMs>,
-    model: Mdl,
-    url_handling: UrlHandling,
-}
-
-impl<Mdl> Init<Mdl> {
-    pub const fn new(model: Mdl) -> Self {
-        Self {
-            model,
-            url_handling: UrlHandling::PassToRoutes,
-        }
-    }
-
-    pub const fn new_with_url_handling(model: Mdl, url_handling: UrlHandling) -> Self {
-        Self {
-            model,
-            url_handling,
-        }
-    }
 }
 
 pub struct Mailbox<Message: 'static> {
@@ -171,170 +134,18 @@ impl<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs> ::std::fmt::Debug
     }
 }
 
-pub trait MountPoint {
-    fn element(self) -> Element;
-}
-
-impl MountPoint for &str {
-    fn element(self) -> Element {
-        util::document().get_element_by_id(self).unwrap_or_else(|| {
-            panic!(
-                "Can't find element with id={:?} - app cannot be mounted!\n\
-                 (Id defaults to \"app\", or can be set with the .mount() method)",
-                self
-            )
-        })
-    }
-}
-
-impl MountPoint for Element {
-    fn element(self) -> Element {
-        self
-    }
-}
-
-impl MountPoint for web_sys::HtmlElement {
-    fn element(self) -> Element {
-        self.into()
-    }
-}
-
-/// Used to create and store initial app configuration, ie items passed by the app creator
-pub struct AppBuilder<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs> {
-    init: InitFn<Ms, Mdl, ElC, GMs>,
-    update: UpdateFn<Ms, Mdl, ElC, GMs>,
-    sink: Option<SinkFn<Ms, Mdl, ElC, GMs>>,
-    view: ViewFn<Mdl, ElC>,
-    mount_point: Option<Element>,
-    takeover_mount: bool,
-    routes: Option<RoutesFn<Ms>>,
-    window_events: Option<WindowEvents<Ms, Mdl>>,
-}
-
-impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, ElC, GMs> {
-    /// Choose the element where the application will be mounted.
-    /// The default one is the element with `id` = "app".
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// // argument is `&str`
-    /// mount("another_id")
-    ///
-    /// // argument is `HTMLElement`
-    /// // NOTE: Be careful with mounting into body,
-    /// // it can cause hard-to-debug bugs when there are other scripts in the body.
-    /// mount(seed::body())
-    ///
-    /// // argument is `Element`
-    /// mount(seed::body().querySelector("section").unwrap().unwrap())
-    /// ```
-    pub fn mount(mut self, mount_point: impl MountPoint) -> Self {
-        // @TODO: Remove as soon as Webkit is fixed and older browsers are no longer in use.
-        // https://github.com/David-OConnor/seed/issues/241
-        // https://bugs.webkit.org/show_bug.cgi?id=202881
-        let _ = util::document().query_selector("html");
-
-        self.mount_point = Some(mount_point.element());
-        self
-    }
-
-    /// Allows for the [`App`] to takeover all the children of the mount point. The default
-    /// behavior is that the [`App`] ignores the children and leaves them in place. The new
-    /// behavior can be useful if SSR is implemented.
-    ///
-    /// As of right now, nodes found in the root will be destroyed and recreated once. This can
-    /// cause duplicated scripts, css, and other tags that should not otherwise be duplicated.
-    /// Unrecognized tags are also converted into spans, so take note.
-    pub fn takeover_mount(mut self, should_takeover: bool) -> Self {
-        self.takeover_mount = should_takeover;
-        self
-    }
-
-    /// Registers a function which maps URLs to messages.
-    pub fn routes(mut self, routes: RoutesFn<Ms>) -> Self {
-        self.routes = Some(routes);
-        self
-    }
-
-    /// Registers a function which decides how window events will be handled.
-    pub fn window_events(mut self, evts: WindowEvents<Ms, Mdl>) -> Self {
-        self.window_events = Some(evts);
-        self
-    }
-
-    /// Registers a sink function.
-    ///
-    /// The sink function is a function which can update the model based
-    /// on global messages. Consider to use a sink function when a
-    /// submodule needs to trigger changes in other modules.
-    pub fn sink(mut self, sink: SinkFn<Ms, Mdl, ElC, GMs>) -> Self {
-        self.sink = Some(sink);
-        self
-    }
-
-    /// Turn this [`AppBuilder`] into an [`App`] which is ready to run.
-    ///
-    /// [`AppBuilder`]: struct.AppBuilder.html
-    /// [`App`]: struct.App.html
-    pub fn finish(mut self) -> App<Ms, Mdl, ElC, GMs> {
-        if self.mount_point.is_none() {
-            self = self.mount("app")
-        }
-
-        let app = App::new(
-            self.update,
-            self.sink,
-            self.view,
-            self.mount_point.unwrap(),
-            self.takeover_mount,
-            self.routes,
-            self.window_events,
-        );
-
-        let mut initial_orders = OrdersContainer::new(app.clone());
-        let mut init = (self.init)(routing::initial_url(), &mut initial_orders);
-
-        match init.url_handling {
-            UrlHandling::PassToRoutes => {
-                let url = routing::initial_url();
-                if let Some(r) = self.routes {
-                    if let Some(u) = r(url) {
-                        (self.update)(u, &mut init.model, &mut initial_orders);
-                    }
-                }
-            }
-            UrlHandling::None => (),
-        };
-
-        app.cfg.initial_orders.replace(Some(initial_orders));
-        app.data.model.replace(Some(init.model));
-
-        app
-    }
-}
-
 /// We use a struct instead of series of functions, in order to avoid passing
 /// repetitive sequences of parameters.
 impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
-    pub fn build(
-        init: impl FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl> + 'static,
+    pub fn build<I: FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>(
+        init: I,
         update: UpdateFn<Ms, Mdl, ElC, GMs>,
         view: ViewFn<Mdl, ElC>,
-    ) -> AppBuilder<Ms, Mdl, ElC, GMs> {
+    ) -> AppBuilder<Ms, Mdl, ElC, GMs, I> {
         // Allows panic messages to output to the browser console.error.
         console_error_panic_hook::set_once();
 
-        AppBuilder {
-            init: Box::new(init),
-            update,
-            view,
-            sink: None,
-            mount_point: None,
-            takeover_mount: false,
-            routes: None,
-            window_events: None,
-        }
+        AppBuilder::new(init, update, view)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -217,7 +217,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
             // TODO: and other, similar things. For now, leave the warning in the builder's
             // TODO: documentation.
             let mut dom_nodes = websys_bridge::el_from_ws_element(&self.cfg.mount_point);
-            dom_nodes.strip_ws_nodes();
+            dom_nodes.strip_own_and_children_ws_nodes();
 
             // Replace the root dom with a placeholder tag and move the children from the root element
             // to the newly created root. Uses `Placeholder` to mimic update logic.

--- a/src/vdom/alias.rs
+++ b/src/vdom/alias.rs
@@ -1,0 +1,8 @@
+use crate::{events, orders::OrdersContainer, routing};
+
+pub type UpdateFn<Ms, Mdl, ElC, GMs> = fn(Ms, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
+pub type SinkFn<Ms, Mdl, ElC, GMs> = fn(GMs, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
+pub type ViewFn<Mdl, ElC> = fn(&Mdl) -> ElC;
+pub type RoutesFn<Ms> = fn(routing::Url) -> Option<Ms>;
+pub type WindowEvents<Ms, Mdl> = fn(&Mdl) -> Vec<events::Listener<Ms>>;
+pub type MsgListeners<Ms> = Vec<Box<dyn Fn(&Ms)>>;

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -1,0 +1,236 @@
+use web_sys::Element;
+
+use crate::{
+    dom_types::View,
+    orders::OrdersContainer,
+    routing, util,
+    vdom::{alias::*, App},
+};
+
+pub trait Initializer<Ms: Clone + 'static, Mdl, ElC: View<Ms>, GMs> {
+    fn into_init(
+        self,
+        routing_method: routing::Url,
+        orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+    ) -> Init<Mdl>;
+}
+impl<Ms: Clone + 'static, Mdl, ElC: View<Ms>, GMs, F> Initializer<Ms, Mdl, ElC, GMs> for F
+where
+    F: FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>,
+{
+    fn into_init(
+        self,
+        routing_method: routing::Url,
+        orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+    ) -> Init<Mdl> {
+        self(routing_method, orders)
+    }
+}
+
+/// Used for handling initial routing.
+pub enum UrlHandling {
+    PassToRoutes,
+    None,
+    // todo: Expand later, as-required
+}
+
+/// Used as a flexible wrapper for the init function.
+pub struct Init<Mdl> {
+    //    init: InitFn<Ms, Mdl, ElC, GMs>,
+    model: Mdl,
+    url_handling: UrlHandling,
+}
+
+impl<Mdl> Init<Mdl> {
+    pub const fn new(model: Mdl) -> Self {
+        Self {
+            model,
+            url_handling: UrlHandling::PassToRoutes,
+        }
+    }
+
+    pub const fn new_with_url_handling(model: Mdl, url_handling: UrlHandling) -> Self {
+        Self {
+            model,
+            url_handling,
+        }
+    }
+}
+
+impl<Mdl: Default> Default for Init<Mdl> {
+    fn default() -> Self {
+        Self::new(Mdl::default())
+    }
+}
+
+pub trait MountPoint {
+    fn element(self) -> Element;
+}
+
+impl MountPoint for &str {
+    fn element(self) -> Element {
+        util::document().get_element_by_id(self).unwrap_or_else(|| {
+            panic!(
+                "Can't find element with id={:?} - app cannot be mounted!\n\
+                 (Id defaults to \"app\", or can be set with the .mount() method)",
+                self
+            )
+        })
+    }
+}
+
+impl MountPoint for Element {
+    fn element(self) -> Element {
+        self
+    }
+}
+
+impl MountPoint for web_sys::HtmlElement {
+    fn element(self) -> Element {
+        self.into()
+    }
+}
+
+/// Used to create and store initial app configuration, ie items passed by the app creator
+pub struct Builder<
+    Ms: 'static + Clone,
+    Mdl: 'static,
+    ElC: View<Ms>,
+    GMs,
+    I: Initializer<Ms, Mdl, ElC, GMs>,
+> {
+    init: I,
+    update: UpdateFn<Ms, Mdl, ElC, GMs>,
+    sink: Option<SinkFn<Ms, Mdl, ElC, GMs>>,
+    view: ViewFn<Mdl, ElC>,
+    mount_point: Option<Element>,
+    takeover_mount: bool,
+    routes: Option<RoutesFn<Ms>>,
+    window_events: Option<WindowEvents<Ms, Mdl>>,
+}
+
+impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static, I: Initializer<Ms, Mdl, ElC, GMs>>
+    Builder<Ms, Mdl, ElC, GMs, I>
+{
+    pub fn new(init: I, update: UpdateFn<Ms, Mdl, ElC, GMs>, view: ViewFn<Mdl, ElC>) -> Self {
+        Self {
+            init,
+            update,
+            view,
+            sink: None,
+            mount_point: None,
+            takeover_mount: false,
+            routes: None,
+            window_events: None,
+        }
+    }
+
+    /// Choose the element where the application will be mounted.
+    /// The default one is the element with `id` = "app".
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// // argument is `&str`
+    /// mount("another_id")
+    ///
+    /// // argument is `HTMLElement`
+    /// // NOTE: Be careful with mounting into body,
+    /// // it can cause hard-to-debug bugs when there are other scripts in the body.
+    /// mount(seed::body())
+    ///
+    /// // argument is `Element`
+    /// mount(seed::body().querySelector("section").unwrap().unwrap())
+    /// ```
+    pub fn mount(mut self, mount_point: impl MountPoint) -> Self {
+        // @TODO: Remove as soon as Webkit is fixed and older browsers are no longer in use.
+        // https://github.com/David-OConnor/seed/issues/241
+        // https://bugs.webkit.org/show_bug.cgi?id=202881
+        let _ = util::document().query_selector("html");
+
+        self.mount_point = Some(mount_point.element());
+        self
+    }
+
+    #[deprecated(since = "0.3.3", note = "please use `mount` instead")]
+    pub fn mount_el(mut self, el: Element) -> Self {
+        self.mount_point = Some(el);
+        self
+    }
+
+    /// Allows for the [`App`] to takeover all the children of the mount point. The default
+    /// behavior is that the [`App`] ignores the children and leaves them in place. The new
+    /// behavior can be useful if SSR is implemented.
+    ///
+    /// As of right now, nodes found in the root will be destroyed and recreated once. This can
+    /// cause duplicated scripts, css, and other tags that should not otherwise be duplicated.
+    /// Unrecognized tags are also converted into spans, so take note.
+    pub fn takeover_mount(mut self, should_takeover: bool) -> Self {
+        self.takeover_mount = should_takeover;
+        self
+    }
+
+    /// Registers a function which maps URLs to messages.
+    pub fn routes(mut self, routes: RoutesFn<Ms>) -> Self {
+        self.routes = Some(routes);
+        self
+    }
+
+    /// Registers a function which decides how window events will be handled.
+    pub fn window_events(mut self, evts: WindowEvents<Ms, Mdl>) -> Self {
+        self.window_events = Some(evts);
+        self
+    }
+
+    /// Registers a sink function.
+    ///
+    /// The sink function is a function which can update the model based
+    /// on global messages. Consider to use a sink function when a
+    /// submodule needs to trigger changes in other modules.
+    pub fn sink(mut self, sink: SinkFn<Ms, Mdl, ElC, GMs>) -> Self {
+        self.sink = Some(sink);
+        self
+    }
+
+    /// Turn this [`AppBuilder`] into an [`App`] which is ready to run.
+    ///
+    /// [`AppBuilder`]: struct.AppBuilder.html
+    /// [`App`]: struct.App.html
+    pub fn finish(mut self) -> App<Ms, Mdl, ElC, GMs> {
+        if self.mount_point.is_none() {
+            self = self.mount("app")
+        }
+
+        let app = App::new(
+            self.update,
+            self.sink,
+            self.view,
+            self.mount_point.unwrap(),
+            self.takeover_mount,
+            self.routes,
+            self.window_events,
+        );
+
+        let mut initial_orders = OrdersContainer::new(app.clone());
+        let mut init = self
+            .init
+            .into_init(routing::initial_url(), &mut initial_orders);
+
+        match init.url_handling {
+            UrlHandling::PassToRoutes => {
+                let url = routing::initial_url();
+                if let Some(r) = self.routes {
+                    if let Some(u) = r(url) {
+                        (self.update)(u, &mut init.model, &mut initial_orders);
+                    }
+                }
+            }
+            UrlHandling::None => (),
+        };
+
+        app.cfg.initial_orders.replace(Some(initial_orders));
+        app.data.model.replace(Some(init.model));
+
+        app
+    }
+}

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -7,14 +7,14 @@ use crate::{
     vdom::{alias::*, App},
 };
 
-pub trait Initializer<Ms: Clone + 'static, Mdl, ElC: View<Ms>, GMs> {
+pub trait Initializer<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
     fn into_init(
         self,
         url: routing::Url,
         orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
     ) -> Init<Mdl>;
 }
-impl<Ms: Clone + 'static, Mdl, ElC: View<Ms>, GMs, F> Initializer<Ms, Mdl, ElC, GMs> for F
+impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> Initializer<Ms, Mdl, ElC, GMs> for F
 where
     F: for<'r, 'a> FnOnce(routing::Url, &'a mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>,
 {
@@ -103,13 +103,8 @@ impl MountPoint for web_sys::HtmlElement {
 }
 
 /// Used to create and store initial app configuration, ie items passed by the app creator
-pub struct Builder<
-    Ms: 'static + Clone,
-    Mdl: 'static,
-    ElC: View<Ms>,
-    GMs,
-    I: Initializer<Ms, Mdl, ElC, GMs>,
-> {
+pub struct Builder<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs, I: Initializer<Ms, Mdl, ElC, GMs>>
+{
     init: I,
     update: UpdateFn<Ms, Mdl, ElC, GMs>,
     sink: Option<SinkFn<Ms, Mdl, ElC, GMs>>,
@@ -119,7 +114,7 @@ pub struct Builder<
     window_events: Option<WindowEvents<Ms, Mdl>>,
 }
 
-impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static, I: Initializer<Ms, Mdl, ElC, GMs>>
+impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static, I: Initializer<Ms, Mdl, ElC, GMs>>
     Builder<Ms, Mdl, ElC, GMs, I>
 {
     pub(super) fn new(

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -345,16 +345,14 @@ pub fn el_from_ws_element<Ms: Clone>(ws: &web_sys::Element) -> El<Ms> {
 
     // Populate attributes
     let mut attrs = dom_types::Attrs::empty();
-    ws
-        .get_attribute_names()
-        .for_each(&mut |attr_name, _, _| {
-            let attr_name2 = attr_name
-                .as_string()
-                .expect("problem converting attr to string");
-            if let Some(attr_val) = ws.get_attribute(&attr_name2) {
-                attrs.add(attr_name2.into(), &attr_val);
-            }
-        });
+    ws.get_attribute_names().for_each(&mut |attr_name, _, _| {
+        let attr_name2 = attr_name
+            .as_string()
+            .expect("problem converting attr to string");
+        if let Some(attr_val) = ws.get_attribute(&attr_name2) {
+            attrs.add(attr_name2.into(), &attr_val);
+        }
+    });
     el.attrs = attrs;
 
     // todo This is the same list in `shortcuts::element_svg!`.

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -15,7 +15,7 @@ fn set_style(el_ws: &web_sys::Node, style: &dom_types::Style) {
 }
 
 /// Recursively create `web_sys::Node`s, and place them in the vdom Nodes' fields.
-pub(crate) fn assign_ws_nodes<Ms: Clone>(document: &Document, node: &mut Node<Ms>)
+pub(crate) fn assign_ws_nodes<Ms>(document: &Document, node: &mut Node<Ms>)
 where
     Ms: 'static,
 {
@@ -93,7 +93,7 @@ fn set_attr_value(el_ws: &web_sys::Node, at: &dom_types::At, at_value: &AtValue)
 /// * [`web_sys` Element](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Element.html)
 /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element\)
 /// * See also: [`web_sys` Node](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Node.html)
-pub(crate) fn make_websys_el<Ms: Clone>(
+pub(crate) fn make_websys_el<Ms>(
     el_vdom: &mut El<Ms>,
     document: &web_sys::Document,
 ) -> web_sys::Node {
@@ -139,7 +139,7 @@ pub fn attach_text_node(text: &mut Text, parent: &web_sys::Node) {
 
 /// Similar to `attach_el_and_children`, but without attaching the elemnt. Useful for
 /// patching, where we want to insert the element at a specific place.
-pub fn attach_children<Ms: Clone>(el_vdom: &mut El<Ms>) {
+pub fn attach_children<Ms>(el_vdom: &mut El<Ms>) {
     let el_ws = el_vdom
         .node_ws
         .as_ref()
@@ -158,7 +158,7 @@ pub fn attach_children<Ms: Clone>(el_vdom: &mut El<Ms>) {
 /// Attaches the element, and all children, recursively. Only run this when creating a fresh vdom node, since
 /// it performs a rerender of the el and all children; eg a potentially-expensive op.
 /// This is where rendering occurs.
-pub fn attach_el_and_children<Ms: Clone>(el_vdom: &mut El<Ms>, parent: &web_sys::Node) {
+pub fn attach_el_and_children<Ms>(el_vdom: &mut El<Ms>, parent: &web_sys::Node) {
     // No parent means we're operating on the top-level element; append it to the main div.
     // This is how we call this function externally, ie not through recursion.
     let el_ws = el_vdom
@@ -196,7 +196,7 @@ pub fn attach_el_and_children<Ms: Clone>(el_vdom: &mut El<Ms>, parent: &web_sys:
     }
 }
 
-fn set_default_element_state<Ms: Clone>(el_ws: &web_sys::Node, el_vdom: &El<Ms>) {
+fn set_default_element_state<Ms>(el_ws: &web_sys::Node, el_vdom: &El<Ms>) {
     // @TODO handle also other Auto* attributes?
     // Set focus because of attribute "autofocus"
     if let Some(at_value) = el_vdom.attrs.vals.get(&dom_types::At::AutoFocus) {
@@ -229,7 +229,7 @@ pub fn _remove_children(el: &web_sys::Node) {
 /// Update the attributes, style, text, and events of an element. Does not
 /// process children, and assumes the tag is the same. Assume we've identfied
 /// the most-correct pairing between new and old.
-pub fn patch_el_details<Ms: Clone>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_sys::Node) {
+pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_sys::Node) {
     // Perform side-effects specified for updating
     if let Some(update_actions) = &mut new.hooks.did_update {
         (update_actions.actions)(old_el_ws) // todo
@@ -335,7 +335,7 @@ pub fn to_mouse_event(event: &web_sys::Event) -> &web_sys::MouseEvent {
 
 /// Create a vdom node from a `web_sys::Element`. See [`node_from_ws`]. Additionally used when
 /// bootstrapping seed on the mount point.
-pub fn el_from_ws_element<Ms: Clone>(ws: &web_sys::Element) -> El<Ms> {
+pub fn el_from_ws_element<Ms>(ws: &web_sys::Element) -> El<Ms> {
     // Result of tag_name is all caps, but tag From<String> expects lower.
     // Probably is more pure to match by xlmns attribute instead.
     let mut el = match ws.tag_name().to_lowercase().as_ref() {
@@ -464,7 +464,7 @@ pub fn el_from_ws_element<Ms: Clone>(ws: &web_sys::Element) -> El<Ms> {
 }
 /// Create a vdom node from a `web_sys::Node`. Used in creating elements from html and markdown
 /// strings. Includes children, recursively added.
-pub fn node_from_ws<Ms: Clone>(node: &web_sys::Node) -> Option<Node<Ms>> {
+pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
     match node.node_type() {
         web_sys::Node::ELEMENT_NODE => {
             // Element node


### PR DESCRIPTION
# Changes:
- Change execution of the initial call to `process_cmd_and_msg_queue` to after the `main_el_vdom` is initialized. This allows for the msg processing to not cause issues if it attempts to force a render or something else similar. Forcing a render on init used to cause Seed to panic.
- Allow Seed to take over the children of the mount. This can be useful for SSR. Built-in SSR for Seed is my goal for now. This is partially related to #232, which is also related to #223.
- Warns of possibly questionable behavior when attempting to accomplish the above maneuver as it is now (see the doc comment for `takeover_mount` in `AppBuilder`). Due to this behavior and backwards compatibility, it is currently an opt in functionality.
- Adds a bunch of utility methods to the `Node` enum.
- Adds a function to recursively remove all workspace `web_sys::Node`s.
# Parts that need additional consideration (incomplete)
- Unsure if the listeners in the bootstrap should be set up -- not familiar with what they do. But it seems to work for now.
- Unsure of any other implications of moving the initial order processing to after the initialization of the `main_el_vdom`.
- Not sure if any of the utility methods added to the `Node` enum are actually of use.
- Might want to fully address the "recreation" behavior of `bootstrap_vdom` before this gets merged.
