### PR TITLE
Better custom el. support

### DIFF
--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -29,7 +29,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
 // View
 
 fn math_tex(expression: &str) -> Node<Msg> {
-    custom![Tag::Custom("math-tex".into()), expression]
+    custom![Tag::from("math-tex"), expression]
 }
 
 fn definition(description: &str, def: &str, index: usize) -> Node<Msg> {

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -530,14 +530,15 @@ macro_rules! make_tags {
             }
         }
 
-        impl From<String> for Tag {
-            fn from(tag: String) -> Self {
+        impl<'a, T: Into<Cow<'a, str>>> From<T> for Tag {
+            fn from(tag: T) -> Self {
+                let tag: Cow<'a, str> = tag.into();
                 match tag.as_ref() {
                     $ (
                           $tag => Tag::$tag_camel,
                     ) +
                     _ => {
-                        Tag::Span
+                        Tag::Custom(tag.to_string())
                     }
                 }
             }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -180,8 +180,15 @@ macro_rules! plain {
 macro_rules! custom {
     ( $($part:expr),* $(,)? ) => {
         {
-            let mut el = El::empty($crate::dom_types::Tag::Custom("missingtagname".into()));
+            let default_tag_name = "missing-tag-name";
+            let mut el = El::empty($crate::dom_types::Tag::from(default_tag_name));
             $ ( $part.update(&mut el); )*
+
+            if let $crate::dom_types::Tag::Custom(tag_name) = &el.tag {
+                let tag_changed = tag_name != default_tag_name;
+                assert!(tag_changed, "Tag has not been set in `custom!` element. Add e.g. `Tag::from(\"code-block\")`.");
+            }
+
             $crate::dom_types::Node::Element(el)
         }
     };


### PR DESCRIPTION
Changes

- `Tag::from` is more flexible and doesn't force to allocate memory for `String`. Non-standard tag is now transformed to `Tag::Custom(..)`.
- Macro `custom!` checks if you set tag. It panics when you forget.
- Super small change in `mathjax` example to demonstrate updated `Tag::from`.

Motivation

- I'm trying to convert Markdown files to HTML and replace `pre` with web components with syntax highlighting. It's impossible without this PR.
