### PR TITLE
Added hashchange listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)
+- The `routes` function now returns an `Option<Msg>` (Breaking)
 - updated `Tag::from()` to accept more input types
 - Improved error-handling
 - Macro `custom!` checks if you set tag, and panics when you forget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)
-- Changed `Tag::Custom` to `Tag::from` (Breaking)
+- updated `Tag::from()` to accept more input types
 - Improved error-handling
-- Macro custom! checks if you set tag, and panics when you forget.
+- Macro `custom!` checks if you set tag, and panics when you forget
 - Fixed a bug with children being absent from cloned elements
 - Improved debugging
-- Added a routing listener for changed hash.
+- Added a routing listener for changed hash
 - Fixed a namespace bug with adding children to `Svg` elements
-- Fixed a bug affecting Safari.
+- Fixed a bug affecting Safari
 
 ## v0.4.1
 - Added more SVG `At` variants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added an `Init` struct, which can help with initial routing (Breaking)
 - The `routes` function now returns an `Option<Msg>` (Breaking)
 - updated `Tag::from()` to accept more input types
+- Fixed a bug affecting element render order
 - Improved error-handling
 - Macro `custom!` checks if you set tag, and panics when you forget
 - Fixed a bug with children being absent from cloned elements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)
+- Changed `Tag::Custom` to `Tag::from` (Breaking)
+- Improved error-handling
+- Macro custom! checks if you set tag, and panics when you forget.
 - Fixed a bug with children being absent from cloned elements
 - Improved debugging
+- Added a routing listener for changed hash.
 - Fixed a namespace bug with adding children to `Svg` elements
+- Fixed a bug affecting Safari.
 
 ## v0.4.1
 - Added more SVG `At` variants

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -379,7 +379,7 @@ name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -426,7 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1021,7 +1021,7 @@ dependencies = [
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ features = [
     "Element",
     "Event",
     "EventTarget",
+    "HashChangeEvent",
     "Headers",
     "History",
     "HtmlElement",

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -372,9 +372,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use wasm_bindgen_test::*;
+
     use super::*;
 
-    #[test]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
     fn parse_url_simple() {
         let expected = Url {
             path: vec!["path1".into(), "path2".into()],
@@ -387,7 +391,7 @@ mod tests {
         assert_eq!(expected, actual)
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn parse_url_with_hash_search() {
         let expected = Url {
             path: vec!["path".into()],
@@ -400,7 +404,7 @@ mod tests {
         assert_eq!(expected, actual)
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn parse_url_with_hash_only() {
         let expected = Url {
             path: vec!["path".into()],

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -268,13 +268,13 @@ pub fn setup_popstate_listener<Ms>(
     Ms: 'static,
 {
     let closure = Closure::new(move |ev: web_sys::Event| {
-
         let ev = ev
             .dyn_ref::<web_sys::PopStateEvent>()
             .expect("Problem casting as Popstate event");
 
         if let Some(state_str) = ev.state().as_string() {
-            let url: Url = serde_json::from_str(&state_str).expect("Problem deserializing popstate state");
+            let url: Url =
+                serde_json::from_str(&state_str).expect("Problem deserializing popstate state");
             // Only update when requested for an update by the user.
             if let Some(routing_msg) = routes(url) {
                 update(routing_msg);
@@ -321,8 +321,8 @@ pub fn setup_hashchange_listener<Ms>(
 /// so we can prevent page refresh for internal links, and route internally.  Run this on load.
 #[allow(clippy::option_map_unit_fn)]
 pub fn setup_link_listener<Ms>(update: impl Fn(Ms) + 'static, routes: fn(Url) -> Option<Ms>)
-    where
-        Ms: 'static,
+where
+    Ms: 'static,
 {
     let closure = Closure::new(move |event: web_sys::Event| {
         event.target()

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -287,7 +287,6 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, 
                     if let Some(u) = r(url) {
                         (self.update)(u, &mut init.model, &mut initial_orders);
                     }
-
                 }
             }
             UrlHandling::None => (),

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -128,6 +128,7 @@ pub struct AppData<Ms: 'static + Clone, Mdl> {
     pub model: RefCell<Option<Mdl>>,
     main_el_vdom: RefCell<Option<El<Ms>>>,
     pub popstate_closure: StoredPopstate,
+    pub hashchange_closure: StoredPopstate,
     pub routes: RefCell<Option<RoutesFn<Ms>>>,
     window_listeners: RefCell<Vec<events::Listener<Ms>>>,
     msg_listeners: RefCell<MsgListeners<Ms>>,
@@ -345,6 +346,7 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GM
                 // This is filled for the first time in run()
                 main_el_vdom: RefCell::new(None),
                 popstate_closure: RefCell::new(None),
+                hashchange_closure: RefCell::new(None),
                 routes: RefCell::new(routes),
                 window_listeners: RefCell::new(Vec::new()),
                 msg_listeners: RefCell::new(Vec::new()),
@@ -415,6 +417,13 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GM
                 enclose!((self => s) move |msg| s.update(msg)),
                 enclose!((self => s) move |closure| {
                     s.data.popstate_closure.replace(Some(closure));
+                }),
+                routes,
+            );
+            routing::setup_hashchange_listener(
+                enclose!((self => s) move |msg| s.update(msg)),
+                enclose!((self => s) move |closure| {
+                    s.data.hashchange_closure.replace(Some(closure));
                 }),
                 routes,
             );

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -284,7 +284,10 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, 
             UrlHandling::PassToRoutes => {
                 let url = routing::initial_url();
                 if let Some(r) = self.routes {
-                    (self.update)(r(url).unwrap(), &mut init.model, &mut initial_orders);
+                    if let Some(u) = r(url) {
+                        (self.update)(u, &mut init.model, &mut initial_orders);
+                    }
+
                 }
             }
             UrlHandling::None => (),


### PR DESCRIPTION
Need to make `Url` parsing from string work with hash and search before merging; currently treats them as part of `path`.