### PR TITLE
Remove the Clone bound from messages where possible.

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -319,7 +319,7 @@ pub fn input_ev<Ms, T: ToString + Copy>(
 
 /// Create an event that passes a `web_sys::KeyboardEvent`, allowing easy access
 /// to items like `key_code`() and key().
-pub fn keyboard_ev<Ms: Clone, T: ToString + Copy>(
+pub fn keyboard_ev<Ms, T: ToString + Copy>(
     trigger: T,
     handler: impl FnOnce(web_sys::KeyboardEvent) -> Ms + 'static + Clone,
 ) -> Listener<Ms> {
@@ -335,7 +335,7 @@ pub fn keyboard_ev<Ms: Clone, T: ToString + Copy>(
 }
 
 /// See `keyboard_ev`
-pub fn mouse_ev<Ms: Clone, T: ToString + Copy>(
+pub fn mouse_ev<Ms, T: ToString + Copy>(
     trigger: T,
     handler: impl FnOnce(web_sys::MouseEvent) -> Ms + 'static + Clone,
 ) -> Listener<Ms> {
@@ -385,7 +385,7 @@ pub fn raw_ev<Ms, T: ToString + Copy>(
 /// in favor of pointing to a message directly.
 pub fn simple_ev<Ms: Clone, T>(trigger: T, message: Ms) -> Listener<Ms>
 where
-    Ms: Clone + 'static,
+    Ms: 'static,
     T: ToString + Copy,
 {
     let msg_closure = message.clone();
@@ -402,7 +402,7 @@ where
 /// Create an event that passes a `web_sys::CustomEvent`, allowing easy access
 /// to detail() and then trigger update
 #[deprecated]
-pub fn trigger_update_ev<Ms: Clone>(
+pub fn trigger_update_ev<Ms>(
     handler: impl FnOnce(web_sys::CustomEvent) -> Ms + 'static + Clone,
 ) -> Listener<Ms> {
     let closure = move |event: web_sys::Event| {
@@ -431,7 +431,7 @@ pub(crate) fn fmt_hook_fn<T>(h: &Option<T>) -> &'static str {
 
 /// Trigger update function from outside of App
 #[deprecated]
-pub fn trigger_update_handler<Ms: Clone + DeserializeOwned>() -> Listener<Ms> {
+pub fn trigger_update_handler<Ms: DeserializeOwned>() -> Listener<Ms> {
     trigger_update_ev(|ev| {
         ev.detail()
             .into_serde()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ mod websys_bridge;
 
 /// Create an element flagged in a way that it will not be rendered. Useful
 /// in ternary operations.
-pub fn empty<Ms: Clone>() -> dom_types::Node<Ms> {
+pub const fn empty<Ms>() -> dom_types::Node<Ms> {
     dom_types::Node::Empty
 }
 

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -5,8 +5,8 @@ use std::{collections::VecDeque, convert::identity, rc::Rc};
 
 // ------ Orders ------
 
-pub trait Orders<Ms: 'static + Clone, GMs = ()> {
-    type AppMs: 'static + Clone;
+pub trait Orders<Ms: 'static, GMs = ()> {
+    type AppMs: 'static;
     type Mdl: 'static;
     type ElC: View<Self::AppMs> + 'static;
 
@@ -19,7 +19,7 @@ pub trait Orders<Ms: 'static + Clone, GMs = ()> {
     ///    child::update(child_msg, &mut model.child, &mut orders.proxy(Msg::Child));
     ///}
     /// ```
-    fn proxy<ChildMs: 'static + Clone>(
+    fn proxy<ChildMs: 'static>(
         &mut self,
         f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
     ) -> OrdersProxy<ChildMs, Self::AppMs, Self::Mdl, Self::ElC, GMs>;
@@ -80,13 +80,13 @@ pub trait Orders<Ms: 'static + Clone, GMs = ()> {
 // ------ OrdersContainer ------
 
 #[allow(clippy::module_name_repetitions)]
-pub struct OrdersContainer<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs = ()> {
+pub struct OrdersContainer<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs = ()> {
     pub(crate) should_render: ShouldRender,
     pub(crate) effects: VecDeque<Effect<Ms, GMs>>,
     app: App<Ms, Mdl, ElC, GMs>,
 }
 
-impl<Ms: Clone, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
+impl<Ms, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
     pub fn new(app: App<Ms, Mdl, ElC, GMs>) -> Self {
         Self {
             should_render: ShouldRender::Render,
@@ -96,7 +96,7 @@ impl<Ms: Clone, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
     }
 }
 
-impl<Ms: 'static + Clone, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
+impl<Ms: 'static, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
     for OrdersContainer<Ms, Mdl, ElC, GMs>
 {
     type AppMs = Ms;
@@ -104,7 +104,7 @@ impl<Ms: 'static + Clone, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
     type ElC = ElC;
 
     #[allow(clippy::redundant_closure)]
-    fn proxy<ChildMs: 'static + Clone>(
+    fn proxy<ChildMs: 'static>(
         &mut self,
         f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
     ) -> OrdersProxy<ChildMs, Ms, Mdl, ElC, GMs> {
@@ -167,19 +167,12 @@ impl<Ms: 'static + Clone, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>
 // ------ OrdersProxy ------
 
 #[allow(clippy::module_name_repetitions)]
-pub struct OrdersProxy<
-    'a,
-    Ms: Clone,
-    AppMs: 'static + Clone,
-    Mdl: 'static,
-    ElC: View<AppMs>,
-    GMs: 'static = (),
-> {
+pub struct OrdersProxy<'a, Ms, AppMs: 'static, Mdl: 'static, ElC: View<AppMs>, GMs: 'static = ()> {
     orders_container: &'a mut OrdersContainer<AppMs, Mdl, ElC, GMs>,
     f: Rc<dyn Fn(Ms) -> AppMs>,
 }
 
-impl<'a, Ms: 'static + Clone, AppMs: 'static + Clone, Mdl, ElC: View<AppMs>, GMs>
+impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs>, GMs>
     OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
 {
     pub fn new(
@@ -193,14 +186,14 @@ impl<'a, Ms: 'static + Clone, AppMs: 'static + Clone, Mdl, ElC: View<AppMs>, GMs
     }
 }
 
-impl<'a, Ms: 'static + Clone, AppMs: 'static + Clone, Mdl, ElC: View<AppMs> + 'static, GMs>
-    Orders<Ms, GMs> for OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
+impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs> + 'static, GMs> Orders<Ms, GMs>
+    for OrdersProxy<'a, Ms, AppMs, Mdl, ElC, GMs>
 {
     type AppMs = AppMs;
     type Mdl = Mdl;
     type ElC = ElC;
 
-    fn proxy<ChildMs: 'static + Clone>(
+    fn proxy<ChildMs: 'static>(
         &mut self,
         f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
     ) -> OrdersProxy<ChildMs, AppMs, Mdl, ElC, GMs> {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -12,7 +12,7 @@ use web_sys::{Document, Window};
 
 /// Recursively attach all event-listeners. Run this after creating elements.
 /// The associated `web_sys` nodes must be assigned prior to running this.
-pub(crate) fn attach_listeners<Ms: Clone>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
+pub(crate) fn attach_listeners<Ms>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
     if let Some(el_ws) = el.node_ws.as_ref() {
         for listener in &mut el.listeners {
             listener.attach(el_ws, mailbox.clone());
@@ -26,7 +26,7 @@ pub(crate) fn attach_listeners<Ms: Clone>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>
 }
 
 /// Recursively detach event-listeners. Run this before patching.
-pub(crate) fn detach_listeners<Ms: Clone>(el: &mut El<Ms>) {
+pub(crate) fn detach_listeners<Ms>(el: &mut El<Ms>) {
     if let Some(el_ws) = el.node_ws.as_ref() {
         for listener in &mut el.listeners {
             listener.detach(el_ws);
@@ -41,7 +41,7 @@ pub(crate) fn detach_listeners<Ms: Clone>(el: &mut El<Ms>) {
 
 /// We reattach all listeners, as with normal Els, since we have no
 /// way of diffing them.
-pub(crate) fn setup_window_listeners<Ms: Clone>(
+pub(crate) fn setup_window_listeners<Ms>(
     window: &Window,
     old: &mut Vec<Listener<Ms>>,
     new: &mut Vec<Listener<Ms>>,
@@ -57,11 +57,7 @@ pub(crate) fn setup_window_listeners<Ms: Clone>(
 }
 
 /// Remove a node from the vdom and `web_sys` DOM.
-pub(crate) fn remove_node<Ms: Clone>(
-    node: &web_sys::Node,
-    parent: &web_sys::Node,
-    el_vdom: &mut El<Ms>,
-) {
+pub(crate) fn remove_node<Ms>(node: &web_sys::Node, parent: &web_sys::Node, el_vdom: &mut El<Ms>) {
     websys_bridge::remove_node(node, parent);
 
     if let Some(unmount_actions) = &mut el_vdom.hooks.will_unmount {
@@ -76,7 +72,7 @@ pub(crate) fn remove_node<Ms: Clone>(
 /// model; don't let them get out of sync from typing or other events, which can occur if a change
 /// doesn't trigger a re-render, or if something else modifies them using a side effect.
 /// Handle controlled inputs: Ie force sync with the model.
-fn setup_input_listener<Ms: Clone>(el: &mut El<Ms>)
+fn setup_input_listener<Ms>(el: &mut El<Ms>)
 where
     Ms: 'static,
 {
@@ -103,7 +99,7 @@ where
 }
 
 /// Recursively sets up input listeners
-pub(crate) fn setup_input_listeners<Ms: Clone>(el_vdom: &mut El<Ms>)
+pub(crate) fn setup_input_listeners<Ms>(el_vdom: &mut El<Ms>)
 where
     Ms: 'static,
 {
@@ -115,7 +111,7 @@ where
     }
 }
 
-fn patch_el<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
+fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     mut old: El<Ms>,
     new: &'a mut El<Ms>,
@@ -197,7 +193,7 @@ fn patch_el<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
     new.node_ws.as_ref()
 }
 
-pub(crate) fn patch_els<'a, Ms: Clone, Mdl, ElC, GMs, OI, NI>(
+pub(crate) fn patch_els<'a, Ms, Mdl, ElC, GMs, OI, NI>(
     document: &Document,
     mailbox: &Mailbox<Ms>,
     app: &App<Ms, Mdl, ElC, GMs>,
@@ -282,7 +278,7 @@ pub(crate) fn patch_els<'a, Ms: Clone, Mdl, ElC, GMs, OI, NI>(
 }
 
 // Reduces code repetition
-fn add_el_helper<Ms: Clone>(
+fn add_el_helper<Ms>(
     new: &mut El<Ms>,
     parent: &web_sys::Node,
     next_node: Option<web_sys::Node>,
@@ -306,7 +302,7 @@ fn add_el_helper<Ms: Clone>(
 
 /// Routes patching through different channels, depending on the Node variant
 /// of old and new.
-pub(crate) fn patch<'a, Ms: Clone, Mdl, ElC: View<Ms>, GMs>(
+pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     document: &Document,
     old: Node<Ms>,
     new: &'a mut Node<Ms>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -231,7 +231,7 @@ pub fn error<T: std::fmt::Debug>(object: T) -> T {
 #[deprecated]
 pub fn update<Ms>(msg: Ms)
 where
-    Ms: Clone + 'static + serde::Serialize,
+    Ms: 'static + serde::Serialize,
 {
     let msg_as_js_value = wasm_bindgen::JsValue::from_serde(&msg)
         .expect("Error: TriggerUpdate - can't serialize given msg!");

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -123,7 +123,7 @@ impl<Ms> Clone for Mailbox<Ms> {
 type StoredPopstate = RefCell<Option<Closure<dyn FnMut(Event)>>>;
 
 /// Used as part of an interior-mutability pattern, ie Rc<RefCell<>>
-pub struct AppData<Ms: 'static + Clone, Mdl> {
+pub struct AppData<Ms: 'static, Mdl> {
     // Model is in a RefCell here so we can modify it in self.update().
     pub model: RefCell<Option<Mdl>>,
     main_el_vdom: RefCell<Option<El<Ms>>>,
@@ -135,7 +135,7 @@ pub struct AppData<Ms: 'static + Clone, Mdl> {
     scheduled_render_handle: RefCell<Option<util::RequestAnimationFrameHandle>>,
 }
 
-pub struct AppCfg<Ms: Clone, Mdl, ElC, GMs>
+pub struct AppCfg<Ms, Mdl, ElC, GMs>
 where
     Ms: 'static,
     Mdl: 'static,
@@ -150,7 +150,7 @@ where
     initial_orders: RefCell<Option<OrdersContainer<Ms, Mdl, ElC, GMs>>>,
 }
 
-pub struct App<Ms: Clone, Mdl, ElC, GMs = ()>
+pub struct App<Ms, Mdl, ElC, GMs = ()>
 where
     Ms: 'static,
     Mdl: 'static,
@@ -162,9 +162,7 @@ where
     pub data: Rc<AppData<Ms, Mdl>>,
 }
 
-impl<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs> ::std::fmt::Debug
-    for App<Ms, Mdl, ElC, GMs>
-{
+impl<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs> ::std::fmt::Debug for App<Ms, Mdl, ElC, GMs> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "App")
     }
@@ -199,7 +197,7 @@ impl MountPoint for web_sys::HtmlElement {
 }
 
 /// Used to create and store initial app configuration, ie items passed by the app creator
-pub struct AppBuilder<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs> {
+pub struct AppBuilder<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs> {
     init: InitFn<Ms, Mdl, ElC, GMs>,
     update: UpdateFn<Ms, Mdl, ElC, GMs>,
     sink: Option<SinkFn<Ms, Mdl, ElC, GMs>>,
@@ -209,7 +207,7 @@ pub struct AppBuilder<Ms: 'static + Clone, Mdl: 'static, ElC: View<Ms>, GMs> {
     window_events: Option<WindowEvents<Ms, Mdl>>,
 }
 
-impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, ElC, GMs> {
+impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, ElC, GMs> {
     /// Choose the element where the application will be mounted.
     /// The default one is the element with `id` = "app".
     ///
@@ -301,7 +299,7 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> AppBuilder<Ms, Mdl, 
 
 /// We use a struct instead of series of functions, in order to avoid passing
 /// repetitive sequences of parameters.
-impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
+impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
     pub fn build(
         init: impl FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl> + 'static,
         update: UpdateFn<Ms, Mdl, ElC, GMs>,
@@ -632,7 +630,7 @@ impl<Ms: Clone, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GM
     }
 }
 
-impl<Ms: Clone, Mdl, ElC: View<Ms>, GMs> Clone for App<Ms, Mdl, ElC, GMs> {
+impl<Ms, Mdl, ElC: View<Ms>, GMs> Clone for App<Ms, Mdl, ElC, GMs> {
     fn clone(&self) -> Self {
         Self {
             cfg: Rc::clone(&self.cfg),

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -15,7 +15,7 @@ fn set_style(el_ws: &web_sys::Node, style: &dom_types::Style) {
 }
 
 /// Recursively create `web_sys::Node`s, and place them in the vdom Nodes' fields.
-pub(crate) fn assign_ws_nodes<Ms: Clone>(document: &Document, node: &mut Node<Ms>)
+pub(crate) fn assign_ws_nodes<Ms>(document: &Document, node: &mut Node<Ms>)
 where
     Ms: 'static,
 {
@@ -93,7 +93,7 @@ fn set_attr_value(el_ws: &web_sys::Node, at: &dom_types::At, at_value: &AtValue)
 /// * [`web_sys` Element](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Element.html)
 /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element\)
 /// * See also: [`web_sys` Node](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Node.html)
-pub(crate) fn make_websys_el<Ms: Clone>(
+pub(crate) fn make_websys_el<Ms>(
     el_vdom: &mut El<Ms>,
     document: &web_sys::Document,
 ) -> web_sys::Node {
@@ -139,7 +139,7 @@ pub fn attach_text_node(text: &mut Text, parent: &web_sys::Node) {
 
 /// Similar to `attach_el_and_children`, but without attaching the elemnt. Useful for
 /// patching, where we want to insert the element at a specific place.
-pub fn attach_children<Ms: Clone>(el_vdom: &mut El<Ms>) {
+pub fn attach_children<Ms>(el_vdom: &mut El<Ms>) {
     let el_ws = el_vdom
         .node_ws
         .as_ref()
@@ -158,7 +158,7 @@ pub fn attach_children<Ms: Clone>(el_vdom: &mut El<Ms>) {
 /// Attaches the element, and all children, recursively. Only run this when creating a fresh vdom node, since
 /// it performs a rerender of the el and all children; eg a potentially-expensive op.
 /// This is where rendering occurs.
-pub fn attach_el_and_children<Ms: Clone>(el_vdom: &mut El<Ms>, parent: &web_sys::Node) {
+pub fn attach_el_and_children<Ms>(el_vdom: &mut El<Ms>, parent: &web_sys::Node) {
     // No parent means we're operating on the top-level element; append it to the main div.
     // This is how we call this function externally, ie not through recursion.
     let el_ws = el_vdom
@@ -196,7 +196,7 @@ pub fn attach_el_and_children<Ms: Clone>(el_vdom: &mut El<Ms>, parent: &web_sys:
     }
 }
 
-fn set_default_element_state<Ms: Clone>(el_ws: &web_sys::Node, el_vdom: &El<Ms>) {
+fn set_default_element_state<Ms>(el_ws: &web_sys::Node, el_vdom: &El<Ms>) {
     // @TODO handle also other Auto* attributes?
     // Set focus because of attribute "autofocus"
     if let Some(at_value) = el_vdom.attrs.vals.get(&dom_types::At::AutoFocus) {
@@ -229,7 +229,7 @@ pub fn _remove_children(el: &web_sys::Node) {
 /// Update the attributes, style, text, and events of an element. Does not
 /// process children, and assumes the tag is the same. Assume we've identfied
 /// the most-correct pairing between new and old.
-pub fn patch_el_details<Ms: Clone>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_sys::Node) {
+pub fn patch_el_details<Ms>(old: &mut El<Ms>, new: &mut El<Ms>, old_el_ws: &web_sys::Node) {
     // Perform side-effects specified for updating
     if let Some(update_actions) = &mut new.hooks.did_update {
         (update_actions.actions)(old_el_ws) // todo
@@ -335,7 +335,7 @@ pub fn to_mouse_event(event: &web_sys::Event) -> &web_sys::MouseEvent {
 
 /// Create a vdom node from a `web_sys::Element`. Used in creating elements from html
 /// and markdown strings. Includes children, recursively added.
-pub fn node_from_ws<Ms: Clone>(node: &web_sys::Node) -> Option<Node<Ms>> {
+pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
     match node.node_type() {
         web_sys::Node::ELEMENT_NODE => {
             // Element node


### PR DESCRIPTION
There was a change that could eliminate most of the times `Msg` needed to have the `Clone` bound.