### PR TITLE
Add `reserve_children` to `Node` and `El`

### DIFF
--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -821,6 +821,14 @@ impl<Ms: Clone> Node<Ms> {
             _ => "".to_string(),
         }
     }
+
+    /// See `El::reserve_children`
+    pub fn reserve_children(&mut self, size: usize) -> &mut Self {
+        if let Node::Element(el) = self {
+            el.reserve_children(size);
+        }
+        self
+    }
 }
 
 impl<Ms: 'static + Clone, OtherMs: 'static + Clone> MessageMapper<Ms, OtherMs> for Node<Ms> {
@@ -1080,6 +1088,12 @@ impl<Ms: Clone> El<Ms> {
                 _ => None,
             })
             .collect()
+    }
+
+    /// Reserve space in the children container of the element
+    pub fn reserve_children(&mut self, size: usize) -> &mut Self {
+        self.children.reserve_exact(size);
+        self
     }
 }
 


### PR DESCRIPTION
-   I could add reserve to other types if appropriate?
-   Should I use `Vec::reserve`, `Vec::reserve_exact` or both? I could have easily done both, just thought it would kind of pollute the API.
-   Any thoughts on bikeshedding or better documentation?

Fixes #262.