### PR TITLE
Method for stripping out the websys node in vdom.

### DIFF
--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -744,18 +744,6 @@ impl<Ms: 'static> Clone for Node<Ms> {
 }
 
 impl<Ms> Node<Ms> {
-    fn is_text(&self) -> bool {
-        if let Node::Text(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn new_text(text: impl Into<Cow<'static, str>>) -> Self {
-        Node::Text(Text::new(text))
-    }
-
     /// See `El::from_markdown`
     pub fn from_markdown(markdown: &str) -> Vec<Node<Ms>> {
         El::from_markdown(markdown)
@@ -832,6 +820,49 @@ impl<Ms> Node<Ms> {
             Node::Element(el) => el.get_text(),
             Node::Text(text) => text.text.to_string(),
             _ => "".to_string(),
+        }
+    }
+}
+
+impl<Ms> Node<Ms> {
+    pub fn new_text(text: impl Into<Cow<'static, str>>) -> Self {
+        Node::Text(Text::new(text))
+    }
+
+    pub fn is_text(&self) -> bool {
+        if let Node::Text(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+    pub fn is_el(&self) -> bool {
+        if let Node::Element(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+    pub fn is_empty(&self) -> bool {
+        if let Node::Empty = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn text(&self) -> Option<&Text> {
+        if let Node::Text(t) = self {
+            Some(t)
+        } else {
+            None
+        }
+    }
+    pub fn el(&self) -> Option<&El<Ms>> {
+        if let Node::Element(e) = self {
+            Some(e)
+        } else {
+            None
         }
     }
 }

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -720,6 +720,10 @@ impl Text {
             node_ws: None,
         }
     }
+
+    pub fn strip_ws_node(&mut self) {
+        self.node_ws.take();
+    }
 }
 
 /// A component in our virtual DOM.
@@ -743,6 +747,7 @@ impl<Ms: 'static> Clone for Node<Ms> {
     }
 }
 
+// Element methods
 impl<Ms> Node<Ms> {
     /// See `El::from_markdown`
     pub fn from_markdown(markdown: &str) -> Vec<Node<Ms>> {
@@ -824,6 +829,7 @@ impl<Ms> Node<Ms> {
     }
 }
 
+// Convenience methods
 impl<Ms> Node<Ms> {
     pub fn new_text(text: impl Into<Cow<'static, str>>) -> Self {
         Node::Text(Text::new(text))
@@ -863,6 +869,17 @@ impl<Ms> Node<Ms> {
             Some(e)
         } else {
             None
+        }
+    }
+}
+
+// Backing node manipulation
+impl<Ms> Node<Ms> {
+    pub fn strip_ws_nodes_from_self_and_children(&mut self) {
+        match self {
+            Node::Text(t) => t.strip_ws_node(),
+            Node::Element(e) => e.strip_ws_nodes_from_self_and_children(),
+            Node::Empty => (),
         }
     }
 }
@@ -1126,6 +1143,14 @@ impl<Ms> El<Ms> {
                 _ => None,
             })
             .collect()
+    }
+
+    /// Remove websys nodes.
+    pub fn strip_ws_nodes_from_self_and_children(&mut self) {
+        self.node_ws.take();
+        for child in &mut self.children {
+            child.strip_ws_nodes_from_self_and_children();
+        }
     }
 }
 


### PR DESCRIPTION
A part of #235.

Also adds a few simple convenience methods for `Node`