### PR TITLE
Tweak bootstrap order so that `main_el_vdom` is initialized first.

### DIFF
--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -195,7 +195,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
         }
     }
 
-    fn bootstrapped_vdom(&self) -> El<Ms> {
+    fn bootstrap_vdom(&self) -> El<Ms> {
         // "new" name is for consistency with `update` function.
         // this section parent is a placeholder, so we can iterate over children
         // in a way consistent with patching code.
@@ -230,7 +230,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
         // Bootstrap the virtual DOM.
         self.data
             .main_el_vdom
-            .replace(Some(self.bootstrapped_vdom()));
+            .replace(Some(self.bootstrap_vdom()));
 
         // Update the state on page load, based
         // on the starting URL. Must be set up on the server as well.

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -260,6 +260,8 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
                 .expect("initial_orders should be set in AppBuilder::finish")
                 .effects,
         );
+        // TODO: In the future, only run the following line if the above statement does not
+        // TODO: call `rerender_vdom` for efficiency.
         self.rerender_vdom();
 
         self

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -14,18 +14,19 @@ fn set_style(el_ws: &web_sys::Node, style: &dom_types::Style) {
         .expect("Problem setting style");
 }
 
+pub(crate) fn assign_ws_nodes_to_el<Ms>(document: &Document, el: &mut El<Ms>) {
+    el.node_ws = Some(make_websys_el(el, document));
+    for mut child in &mut el.children {
+        assign_ws_nodes(document, &mut child);
+    }
+}
 /// Recursively create `web_sys::Node`s, and place them in the vdom Nodes' fields.
 pub(crate) fn assign_ws_nodes<Ms>(document: &Document, node: &mut Node<Ms>)
 where
     Ms: 'static,
 {
     match node {
-        Node::Element(el) => {
-            el.node_ws = Some(make_websys_el(el, document));
-            for mut child in &mut el.children {
-                assign_ws_nodes(document, &mut child);
-            }
-        }
+        Node::Element(el) => assign_ws_nodes_to_el(document, el),
         Node::Text(text) => {
             text.node_ws = Some(
                 document


### PR DESCRIPTION
Part of #235.

Forces `process_cmd_and_msg_queue` to occur after the `main_el_vdom` is initialized, making it consistent with all other calls of `process_cmd_and_msg_queue`.

Also removes an extra `Node` wrapping for calling `assign_ws_nodes_to_el` when bootstrapping the vdom.