### PR TITLE
Added `AppBuilder.start()`, combining `finish()` and `run()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Added a `hashchange` listener
 - Added a routing listener for changed hash
 - Fixed a namespace bug with adding children to `Svg` elements
 - Fixed a bug affecting Safari
-- Added a `seed::html_document()` and `seed::cookies` convenience functions
+- Added `seed::html_document()` and `seed::cookies` convenience functions
 
 ## v0.4.1
 - Added more SVG `At` variants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 - Added an `Init` struct, which can help with initial routing (Breaking)
 - The `routes` function now returns an `Option<Msg>` (Breaking)
 - Updated `Tag::from()` to accept more input types
-- `style!` now accepts types that implement the new `ToCssValue` trait
+- `style!` now accepts also `Option<impl ToString>`
 - Fixed a bug affecting element render order
-Added a `hashchange` listener
+- Added a `hashchange` listener
 - Improved error-handling
-- Tweakd bootstrap order so that `main_el_vdom` is initialized first (internal)
+- Tweaked bootstrap order so that `main_el_vdom` is initialized first (internal)
 - Macro `custom!` checks if you set tag, and panics when you forget
 - Fixed a bug with children being absent from cloned elements
 - Improved debugging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,19 @@
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)
 - The `routes` function now returns an `Option<Msg>` (Breaking)
-- updated `Tag::from()` to accept more input types
+- Updated `Tag::from()` to accept more input types
+- `style!` now accepts types that implement the new `ToCssValue` trait
 - Fixed a bug affecting element render order
 Added a `hashchange` listener
 - Improved error-handling
+- Tweakd bootstrap order so that `main_el_vdom` is initialized first (internal)
 - Macro `custom!` checks if you set tag, and panics when you forget
 - Fixed a bug with children being absent from cloned elements
 - Improved debugging
 - Added a routing listener for changed hash
 - Fixed a namespace bug with adding children to `Svg` elements
 - Fixed a bug affecting Safari
+- Added a `seed::html_document()` and `seed::cookies` convenience functions
 
 ## v0.4.1
 - Added more SVG `At` variants

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ fn view(model: &Model) -> impl View<Msg> {
 #[wasm_bindgen(start)]
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
-        .start();
+        .build_and_run();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ fn view(model: &Model) -> impl View<Msg> {
 #[wasm_bindgen(start)]
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
-        .build_and_run();
+        .build_and_start();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,8 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Model::default(), update, view)
-        .finish()
-        .run();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view)
+        .start();
 }
 ```
 

--- a/examples/animation_frame/src/lib.rs
+++ b/examples/animation_frame/src/lib.rs
@@ -182,5 +182,5 @@ fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
 pub fn render() {
     seed::App::build(init, update, view)
         .window_events(|_| vec![simple_ev(Ev::Resize, Msg::SetViewportWidth)])
-        .start();
+        .build_and_run();
 }

--- a/examples/animation_frame/src/lib.rs
+++ b/examples/animation_frame/src/lib.rs
@@ -182,5 +182,5 @@ fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
 pub fn render() {
     seed::App::build(init, update, view)
         .window_events(|_| vec![simple_ev(Ev::Resize, Msg::SetViewportWidth)])
-        .build_and_run();
+        .build_and_start();
 }

--- a/examples/animation_frame/src/lib.rs
+++ b/examples/animation_frame/src/lib.rs
@@ -182,6 +182,5 @@ fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
 pub fn render() {
     seed::App::build(init, update, view)
         .window_events(|_| vec![simple_ev(Ev::Resize, Msg::SetViewportWidth)])
-        .finish()
-        .run();
+        .start();
 }

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -105,5 +105,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).start();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_run();
 }

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -105,7 +105,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view)
-        .finish()
-        .run();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).start();
 }

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -105,5 +105,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_run();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_start();
 }

--- a/examples/drop/src/lib.rs
+++ b/examples/drop/src/lib.rs
@@ -117,5 +117,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).finish().run();
+    seed::App::build(init, update, view).start();
 }

--- a/examples/drop/src/lib.rs
+++ b/examples/drop/src/lib.rs
@@ -117,5 +117,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).start();
+    seed::App::build(init, update, view).build_and_run();
 }

--- a/examples/drop/src/lib.rs
+++ b/examples/drop/src/lib.rs
@@ -117,5 +117,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).build_and_run();
+    seed::App::build(init, update, view).build_and_start();
 }

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -233,5 +233,5 @@ fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).finish().run();
+    seed::App::build(init, update, view).start();
 }

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -233,5 +233,5 @@ fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).start();
+    seed::App::build(init, update, view).build_and_run();
 }

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -233,5 +233,5 @@ fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).build_and_run();
+    seed::App::build(init, update, view).build_and_start();
 }

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -94,5 +94,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).start();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_run();
 }

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -94,5 +94,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_run();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_start();
 }

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -94,7 +94,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view)
-        .finish()
-        .run();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).start();
 }

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -459,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "copyless"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1316,7 @@ name = "seed"
 version = "0.4.1"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2002,6 +2012,7 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+"checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum copyless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59de7722d3b5c7b35dd519d617fe5116c9b879a0f145dc5431d78ab1f61d7c23"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -107,5 +107,5 @@ fn view_example_introduction(title: &str, description: &str) -> Vec<Node<Msg>> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).start();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_run();
 }

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -107,5 +107,5 @@ fn view_example_introduction(title: &str, description: &str) -> Vec<Node<Msg>> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_run();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_start();
 }

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -107,7 +107,5 @@ fn view_example_introduction(title: &str, description: &str) -> Vec<Node<Msg>> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view)
-        .finish()
-        .run();
+    seed::App::build(|_, _| Init::new(Model::default()), update, view).start();
 }

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -135,5 +135,5 @@ fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).build_and_run();
+    seed::App::build(init, update, view).build_and_start();
 }

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -135,5 +135,5 @@ fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).start();
+    seed::App::build(init, update, view).build_and_run();
 }

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -135,5 +135,5 @@ fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).finish().run();
+    seed::App::build(init, update, view).start();
 }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -363,6 +363,5 @@ fn routes(url: seed::Url) -> Option<Msg> {
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
         .routes(routes)
-        .finish()
-        .run();
+        .start();
 }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -363,5 +363,5 @@ fn routes(url: seed::Url) -> Option<Msg> {
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
         .routes(routes)
-        .start();
+        .build_and_run();
 }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -363,5 +363,5 @@ fn routes(url: seed::Url) -> Option<Msg> {
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
         .routes(routes)
-        .build_and_run();
+        .build_and_start();
 }

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -76,7 +76,7 @@ fn view(model: &Model) -> Node<Msg> {
 #[wasm_bindgen]
 // `wasm-bindgen` cannot transfer struct with public closures to JS (yet) so we have to send slice.
 pub fn start() -> Box<[JsValue]> {
-    let app = seed::App::build(init, update, view).finish().run();
+    let app = seed::App::build(init, update, view).build_and_start();
 
     create_closures_for_js(&app)
 }

--- a/examples/user_media/src/lib.rs
+++ b/examples/user_media/src/lib.rs
@@ -74,5 +74,5 @@ fn view(_: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).finish().run();
+    seed::App::build(init, update, view).start();
 }

--- a/examples/user_media/src/lib.rs
+++ b/examples/user_media/src/lib.rs
@@ -74,5 +74,5 @@ fn view(_: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).build_and_run();
+    seed::App::build(init, update, view).build_and_start();
 }

--- a/examples/user_media/src/lib.rs
+++ b/examples/user_media/src/lib.rs
@@ -74,5 +74,5 @@ fn view(_: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).start();
+    seed::App::build(init, update, view).build_and_run();
 }

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -154,5 +154,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    App::build(init, update, view).finish().run();
+    App::build(init, update, view).start();
 }

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -154,5 +154,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    App::build(init, update, view).start();
+    App::build(init, update, view).build_and_run();
 }

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -154,5 +154,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    App::build(init, update, view).build_and_run();
+    App::build(init, update, view).build_and_start();
 }

--- a/examples/window_events/src/lib.rs
+++ b/examples/window_events/src/lib.rs
@@ -85,6 +85,5 @@ fn window_events(model: &Model) -> Vec<Listener<Msg>> {
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
         .window_events(window_events)
-        .finish()
-        .run();
+        .start();
 }

--- a/examples/window_events/src/lib.rs
+++ b/examples/window_events/src/lib.rs
@@ -85,5 +85,5 @@ fn window_events(model: &Model) -> Vec<Listener<Msg>> {
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
         .window_events(window_events)
-        .build_and_run();
+        .build_and_start();
 }

--- a/examples/window_events/src/lib.rs
+++ b/examples/window_events/src/lib.rs
@@ -85,5 +85,5 @@ fn window_events(model: &Model) -> Vec<Listener<Msg>> {
 pub fn render() {
     seed::App::build(|_, _| Init::new(Model::default()), update, view)
         .window_events(window_events)
-        .start();
+        .build_and_run();
 }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -226,7 +226,10 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
 
     /// App initialization: Collect its fundamental components, setup, and perform
     /// an initial render.
-    #[deprecated(since = "0.4.2", note = "Please use `AppBuilder.build_and_run` instead")]
+    #[deprecated(
+        since = "0.4.2",
+        note = "Please use `AppBuilder.build_and_start` instead"
+    )]
     pub fn run(self) -> Self {
         // Bootstrap the virtual DOM.
         self.data.main_el_vdom.replace(Some(self.bootstrap_vdom()));

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -228,9 +228,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
     /// an initial render.
     pub fn run(self) -> Self {
         // Bootstrap the virtual DOM.
-        self.data
-            .main_el_vdom
-            .replace(Some(self.bootstrap_vdom()));
+        self.data.main_el_vdom.replace(Some(self.bootstrap_vdom()));
 
         // Update the state on page load, based
         // on the starting URL. Must be set up on the server as well.

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -226,6 +226,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
 
     /// App initialization: Collect its fundamental components, setup, and perform
     /// an initial render.
+    #[deprecated(since = "0.4.2", note = "Please use `AppBuilder.build_and_run` instead")]
     pub fn run(self) -> Self {
         // Bootstrap the virtual DOM.
         self.data.main_el_vdom.replace(Some(self.bootstrap_vdom()));

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -182,7 +182,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs> 
     }
 
     /// Start the app; wraps `.finish()` and `.start()`.
-    pub fn start(self) -> App<Ms, Mdl, ElC, GMs> {
+    pub fn build_and_run(self) -> App<Ms, Mdl, ElC, GMs> {
         let app = self.finish();
         app.run()
     }

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -146,7 +146,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs> 
     ///
     /// [`Builder`]: struct.Builder.html
     /// [`App`]: struct.App.html
-    #[deprecated(since = "0.4.2", note = "Please use `.build_and_run` instead")]
+    #[deprecated(since = "0.4.2", note = "Please use `.build_and_start` instead")]
     pub fn finish(mut self) -> App<Ms, Mdl, ElC, GMs> {
         if self.mount_point.is_none() {
             self = self.mount("app")
@@ -183,7 +183,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs> 
     }
 
     /// Build and run the app.
-    pub fn build_and_run(self) -> App<Ms, Mdl, ElC, GMs> {
+    pub fn build_and_start(self) -> App<Ms, Mdl, ElC, GMs> {
         let app = self.finish();
         app.run()
     }

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -146,6 +146,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs> 
     ///
     /// [`Builder`]: struct.Builder.html
     /// [`App`]: struct.App.html
+    #[deprecated(since = "0.4.2", note = "Please use `.build_and_run` instead")]
     pub fn finish(mut self) -> App<Ms, Mdl, ElC, GMs> {
         if self.mount_point.is_none() {
             self = self.mount("app")
@@ -181,7 +182,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs> 
         app
     }
 
-    /// Start the app; wraps `.finish()` and `.start()`.
+    /// Build and run the app.
     pub fn build_and_run(self) -> App<Ms, Mdl, ElC, GMs> {
         let app = self.finish();
         app.run()

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -4,8 +4,6 @@ use super::{alias::*, App};
 
 use crate::{dom_types::View, orders::OrdersContainer, routing, util};
 
-//type InitFn<Ms, Mdl, ElC, GMs> =
-//    Box<dyn FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Mdl>;
 pub type InitFn<Ms, Mdl, ElC, GMs> =
     Box<dyn FnOnce(routing::Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>;
 
@@ -46,7 +44,6 @@ pub enum UrlHandling {
 
 /// Used as a flexible wrapper for the init function.
 pub struct Init<Mdl> {
-    //    init: InitFn<Ms, Mdl, ElC, GMs>,
     model: Mdl,
     url_handling: UrlHandling,
 }
@@ -182,5 +179,11 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs> 
         app.data.model.replace(Some(init.model));
 
         app
+    }
+
+    /// Start the app; wraps `.finish()` and `.start()`.
+    pub fn start(self) -> App<Ms, Mdl, ElC, GMs> {
+        let app = self.finish();
+        app.run()
     }
 }


### PR DESCRIPTION
Added alternative starting code: `AppBuilder.start()`, which combines `.finish()` and `.run()`. These two are usually associated with each other. This flow's a little cleaner.

```rust
#[wasm_bindgen(start)]
pub fn render() {
    seed::App::build(|_, _| Init::new(Model::default()), update, view)
        .finish()
        .run();
}
```

 to 

```rust
#[wasm_bindgen(start)]
pub fn render() {
    seed::App::build(|_, _| Init::new(Model::default()), update, view)
        .start();
}
```

Are there any cases where we do something between `finish()` and `run()`? Can still do the former, but am wondering for documentation purposes.

Open to alternatives / further simplifications / renames etc. For example, what do you think about `seed::build` to start, instead of `seed::App::build`? This would be a little simpler, but hides that it's instantiating an `App`.

Overall intent is to minimize boilerplate, if we can do it with minimal drawbacks.
