### PR TITLE
Add parameter for specifying what to do with elements that already exist within the mount.

### DIFF
--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -459,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "copyless"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1316,7 @@ name = "seed"
 version = "0.4.1"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2002,6 +2012,7 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+"checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum copyless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59de7722d3b5c7b35dd519d617fe5116c9b879a0f145dc5431d78ab1f61d7c23"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::{
     fetch::{Method, Request},
     routing::{push_route, Url},
     util::{body, cookies, document, error, history, html_document, log, update, window},
-    vdom::{App, AppBuilder},
+    vdom::{App, AppBuilder, MountType},
     websys_bridge::{to_html_el, to_input, to_kbevent, to_mouse_event, to_select, to_textarea},
 };
 use wasm_bindgen::{closure::Closure, JsCast};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::{
     fetch::{Method, Request},
     routing::{push_route, Url},
     util::{body, cookies, document, error, history, html_document, log, update, window},
-    vdom::{App, AppBuilder, MountType},
+    vdom::{App, AppBuilder},
     websys_bridge::{to_html_el, to_input, to_kbevent, to_mouse_event, to_select, to_textarea},
 };
 use wasm_bindgen::{closure::Closure, JsCast};
@@ -97,7 +97,7 @@ pub mod prelude {
             request_animation_frame, ClosureNew, RequestAnimationFrameHandle,
             RequestAnimationFrameTime,
         },
-        vdom::{Init, UrlHandling},
+        vdom::{Init, UrlHandling, MountType},
     };
     pub use indexmap::IndexMap; // for attrs and style to work.
     pub use wasm_bindgen::prelude::*;

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -212,11 +212,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
             // Construct a vdom from the root element. Subsequently strip the workspace so that we
             // can recreate it later - this is a kind of simple way to avoid missing nodes (but
             // not entirely correct).
-            // TODO: 1) Optimize by utilizing a patching strategy instead of recreating the workspace
-            // TODO: nodes.
-            // TODO: 2) Watch out for elements that should not be recreated, such as script nodes,
-            // TODO: and other, similar things. For now, leave the warning in the builder's
-            // TODO: documentation.
+            // TODO: 1) Please refer to [issue #277](https://github.com/David-OConnor/seed/issues/277)
             let mut dom_nodes: El<Ms> = (&self.cfg.mount_point).into();
             dom_nodes.strip_ws_nodes_from_self_and_children();
 
@@ -232,7 +228,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
         // Recreate the needed nodes. Only do this if requested to takeover the mount point since
         // it should only be needed here.
         if mount_type == MountType::Takeover {
-            // TODO: Refer the Optimization TODO.
+            // TODO: Please refer to [issue #277](https://github.com/David-OConnor/seed/issues/277)
             websys_bridge::assign_ws_nodes_to_el(&util::document(), &mut new);
 
             // Remove all old elements. We'll swap them out with the newly created elements later.

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -38,17 +38,38 @@ impl MountPoint for web_sys::HtmlElement {
 }
 
 /// Used for handling initial routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UrlHandling {
     PassToRoutes,
     None,
     // todo: Expand later, as-required
 }
 
+/// Describes the handling of elements already present in the mount element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MountType {
+    /// Take control of previously existing elements in the mount. This does not make guarantees of
+    /// elements added after the [`App`] has been mounted.
+    ///
+    /// Note that existing elements in the DOM will be recreated. This can be dangerous for script
+    /// tags and other, similar tags.
+    Takeover,
+    /// Leave the previously existing elements in the mount alone. This does not make guarantees of
+    /// elements added after the [`App`] has been mounted.
+    Append,
+}
+
 /// Used as a flexible wrapper for the init function.
 pub struct Init<Mdl> {
     //    init: InitFn<Ms, Mdl, ElC, GMs>,
-    model: Mdl,
-    url_handling: UrlHandling,
+    /// Initial model to be used when the app begins.
+    pub model: Mdl,
+    /// How to handle initial url routing. Defaults to [`UrlHandling::PassToRoutes`] in the
+    /// constructors.
+    pub url_handling: UrlHandling,
+    /// How to handle elements already present in the mount. Defaults to [`MountType::Append`]
+    /// in the constructors.
+    pub mount_type: MountType,
 }
 
 impl<Mdl> Init<Mdl> {
@@ -56,6 +77,7 @@ impl<Mdl> Init<Mdl> {
         Self {
             model,
             url_handling: UrlHandling::PassToRoutes,
+            mount_type: MountType::Append,
         }
     }
 
@@ -63,6 +85,17 @@ impl<Mdl> Init<Mdl> {
         Self {
             model,
             url_handling,
+            mount_type: MountType::Append,
+        }
+    }
+}
+
+impl<Mdl: Default> Default for Init<Mdl> {
+    fn default() -> Self {
+        Self {
+            model: Mdl::default(),
+            url_handling: UrlHandling::PassToRoutes,
+            mount_type: MountType::Append,
         }
     }
 }
@@ -179,6 +212,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs> 
         };
 
         app.cfg.initial_orders.replace(Some(initial_orders));
+        app.cfg.mount_type.replace(Some(init.mount_type));
         app.data.model.replace(Some(init.model));
 
         app


### PR DESCRIPTION
The last part of #235.

- Allow Seed to take over the children of the mount. This can be useful for SSR. This is partially related to #232, which is also related to #223.
- Warns of possibly questionable behavior when attempting to accomplish the above maneuver as it is now (see the doc comment for `takeover_mount` in `AppBuilder`). Due to this behavior and backwards compatibility, it is currently an opt in functionality.