### PR TITLE
Fix - hash routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [unreleased]
 - Added helper `seed::canvas()`, and `seed::canvas_context()` helper functions
+- Fixed `Url` parsing (resolves issue with hash routing)
+- [BREAKING] `From<String> for Url` changed to `TryFrom<String> for Url`
 
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ features = [
     "Window",
     "KeyboardEvent",
     "InputEvent",
+    "Url",
 ]
 
 [workspace]

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -71,6 +71,7 @@ fn _dirac_3(left: &str, middle: &str, right: &str) -> String {
     )
 }
 
+#[allow(clippy::too_many_lines)]
 fn view(model: &Model) -> impl View<Msg> {
     div![
         style!{

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -346,11 +346,11 @@ mod tests {
         let expected = Url {
             path: vec!["path".into()],
             hash: Some("hash".into()),
-            search: Some("sea=rch".into()),
+            search: Some("search=query".into()),
             title: None,
         };
 
-        let actual: Url = "/path/#hash?sea=rch".to_string().into();
+        let actual: Url = "/path?search=query#hash".to_string().into();
         assert_eq!(expected, actual)
     }
 
@@ -363,7 +363,7 @@ mod tests {
             title: None,
         };
 
-        let actual: Url = "/path/#hash".to_string().into();
+        let actual: Url = "/path#hash".to_string().into();
         assert_eq!(expected, actual)
     }
 

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -151,24 +151,11 @@ pub fn initial_url() -> Url {
         .into()
 }
 
-fn remove_first(s: &str) -> Option<&str> {
-    s.chars().next().map(|c| &s[c.len_utf8()..])
-}
-
 /// Remove prepended / from all items in the Url's path.
 fn clean_url(mut url: Url) -> Url {
-    let mut cleaned_path = vec![];
-    for part in &url.path {
-        if let Some(first) = part.chars().next() {
-            if first == '/' {
-                cleaned_path.push(remove_first(part).unwrap().to_string());
-            } else {
-                cleaned_path.push(part.to_string());
-            }
-        }
-    }
-
-    url.path = cleaned_path;
+    url.path = url.path.into_iter().map(|path_part| {
+        path_part.trim_start_matches('/').to_owned()
+    }).collect();
     url
 }
 

--- a/src/websys_bridge.rs
+++ b/src/websys_bridge.rs
@@ -334,6 +334,7 @@ pub fn to_mouse_event(event: &web_sys::Event) -> &web_sys::MouseEvent {
         .expect("Unable to cast as a mouse event")
 }
 
+#[allow(clippy::too_many_lines)]
 impl<Ms> From<&web_sys::Element> for El<Ms> {
     /// Create a vdom node from a `web_sys::Element`. Used in creating elements from html
     /// and markdown strings. Includes children, recursively added.


### PR DESCRIPTION
There were bugs in `Url` parsing (see new and updated tests). 
I've refactored `routing.rs` to use native `web_sys::Url` for parsing and fixed some new clippy errors.
Tested with projects which uses hash routing and standard routing.

@David-OConnor What's the real purpose of function `clean_url`?
https://github.com/David-OConnor/seed/blob/8a6d60acd659fed1bb53db0dbd17ccc1826176e8/src/routing.rs#L208