### PR TITLE
after_next_render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `Url` parsing (resolves issue with hash routing)
 - [BREAKING] `From<String> for Url` changed to `TryFrom<String> for Url`
 - Fixed jumping cursor in inputs (#158) 
+- Added method `orders.after_next_render(Option<RenderTimestampDelta>)` (#207)
 
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -4,7 +4,6 @@
 extern crate seed;
 
 use futures::prelude::*;
-// todo: crate:: here is temporary, until gloo_timers is published.
 use gloo_timers::future::TimeoutFuture;
 use seed::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub mod prelude {
             request_animation_frame, ClosureNew, RequestAnimationFrameHandle,
             RequestAnimationFrameTime,
         },
-        vdom::{Init, MountType, UrlHandling},
+        vdom::{Init, MountType, RenderTimestampDelta, UrlHandling},
     };
     pub use indexmap::IndexMap; // for attrs and style to work.
     pub use wasm_bindgen::prelude::*;

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -78,13 +78,15 @@ pub trait Orders<Ms: 'static, GMs = ()> {
 
     /// Register the callback that will be executed after the next render.
     ///
-    /// Callback's only parameter is a render timestamp delta - i.e. difference between the old render timestamp and the new one.
-    /// The parameter has value `None` if it's the first render.
+    /// Callback's only parameter is `Option<RenderTimestampDelta>` - the difference between
+    /// the old render timestamp and the new one.
+    /// The parameter has value `None` if it's the first rendering.
     ///
     /// - It's useful when you want to use DOM API or make animations.
     /// - You can call this function multiple times - callbacks will be executed in the same order.
     ///
-    /// _Note:_ [performance.now()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) is used under the hood to get timestamps.
+    /// _Note:_ [performance.now()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)
+    ///  is used under the hood to get timestamps.
     fn after_next_render(
         &mut self,
         callback: impl FnOnce(Option<RenderTimestampDelta>) -> Ms + 'static,

--- a/src/util.rs
+++ b/src/util.rs
@@ -49,16 +49,11 @@ pub fn html_document() -> web_sys::HtmlDocument {
     wasm_bindgen::JsValue::from(document()).unchecked_into::<web_sys::HtmlDocument>()
 }
 /// Convenience function to access the `web_sys::HtmlCanvasElement`.
+/// /// _Note:_ Returns `None` if there is no element with the given `id` or the element isn't `HtmlCanvasElement`.
 pub fn canvas(id: &str) -> Option<web_sys::HtmlCanvasElement> {
-    if let Some(c) = document().get_element_by_id(id) {
-        Some(
-            c.dyn_into::<web_sys::HtmlCanvasElement>()
-                .map_err(|_| ())
-                .expect("Problem casting as web_sys::HtmlCanvasElement"),
-        )
-    } else {
-        None
-    }
+    document()
+        .get_element_by_id(id)
+        .and_then(|element| element.dyn_into::<web_sys::HtmlCanvasElement>().ok())
 }
 
 /// Convenience function to access the `web_sys::CanvasRenderingContext2d`.
@@ -314,7 +309,7 @@ pub fn error<T: std::fmt::Debug>(object: T) -> T {
 /// and to register `trigger_update_handler` in `window_events`.
 /// Consider to use [`App::update`](struct.App.html#method.update) if you have access to the [`App`](struct.App.html) instance.
 ///
-/// _Note_: Function is `deprecated`. See examples `update_from_js`, `websocket` and `animation_frame` for alternatives.
+/// _Note_: Function is `deprecated`. See examples `update_from_js` and `websocket` for alternatives.
 #[deprecated]
 pub fn update<Ms>(msg: Ms)
 where


### PR DESCRIPTION
Resolves #207 

Changes
 - Added method `orders.after_next_render(Option<RenderTimestampDelta>)`.
 - Updated and refactored examples `animation_frame` and `canvas`.
 - Refactored function `canvas`.

No breaking changes.