### PR TITLE
feat: Exposed console_error_panic_hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Relaxed `view` and `update` type in `App::start` from `fn` to `FnOnce + Clone`.
 - [BREAKING] Removed deprecated `Ev::TriggerUpdate`.
 - [deprecated] `simple_ev` is deprecated.
+- Exposed dependency `console_error_panic_hook`.
 
 ## v0.7.0
 - [BREAKING] Custom elements are now patched in-place (#364). Use `el_key` to force reinitialize an element.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ js-sys = "0.3.40"
 pulldown-cmark = "0.7.1"
 rand = { version = "0.7.3", features = ["wasm-bindgen", "small_rng"] }
 serde = { version = "1.0.111", features = ['derive'] }
-serde_json = "1.0.53"
+serde_json = "1.0.55"
 wasm-bindgen = {version = "0.2.63", features = ["serde-serialize"]}
 wasm-bindgen-futures = "0.4.13"
 # @TODO: remove once we can use entities without `Debug` in `log!` and `error!` on `stable` Rust.

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/server.rs"
 [dependencies]
 # common
 serde = { version = "1.0.111", features = ["derive"] }
-serde_json = "1.0.53"
+serde_json = "1.0.55"
 rmp-serde = "0.14"
 
 # server

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ pub use crate::{
     },
     virtual_dom::{Attrs, EventHandler, Style},
 };
+pub use console_error_panic_hook;
 pub use futures::future::{FutureExt, TryFutureExt};
 use wasm_bindgen::{closure::Closure, JsCast};
 


### PR DESCRIPTION
It allows to write e.g.:
```rust
#[wasm_bindgen(start)]
pub fn start() {
    console_error_panic_hook::set_once();

    let root_element = document()
        .get_elements_by_tag_name("section")
        .item(0)
        .expect("`section` as a root element");

    App::start(root_element, init, update, view);
}
```
without adding extra dependencies into users `Cargo.toml`.